### PR TITLE
v1.7.0: web UI, comment soft delete, project scoping, and a big token cut

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@
 *.db-wal
 *.db-shm
 icon.svg
+test/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ lived in the context window, or in a `TODO.md` nobody updates.
 
 saga-mcp gives the agent a real tracker instead: a SQLite file in your project
 holding projects, epics, tasks, subtasks, dependencies, comments, notes and
-decisions, exposed as 31 MCP tools. The agent writes to it as it works and
+decisions, exposed as 33 MCP tools. The agent writes to it as it works and
 reads the dashboard when it comes back. No accounts, no external service, no
 network calls — the database is a file you own.
 
@@ -65,14 +65,15 @@ recent activity, notes.
 
 - **Full hierarchy**: Projects > Epics > Tasks > Subtasks
 - **Task dependencies**: Express sequencing with auto-block/unblock when deps are met
-- **Comments**: Threaded discussions on tasks — leave breadcrumbs across sessions
+- **Comments**: Threaded discussions on tasks — leave breadcrumbs across sessions, with reversible soft-delete
+- **Web UI**: `saga-web` serves a local dashboard for browsing *and* editing the same database
 - **Templates**: Reusable task sets with `{variable}` substitution
 - **Dashboard**: One tool call gives full overview with natural language summary
 - **SQLite**: Self-contained `.tracker.db` file per project — zero setup, no external database
 - **Activity log**: Every mutation is automatically tracked with old/new values
 - **Notes system**: Decisions, context, meeting notes, blockers — all searchable
 - **Batch operations**: Create multiple subtasks or update multiple tasks in one call
-- **31 focused tools**: With MCP safety annotations on every tool
+- **33 focused tools**: With MCP safety annotations on every tool
 - **Import/export**: Full project backup and migration as JSON (with dependencies and comments)
 - **Source references**: Link tasks to specific code locations
 - **Auto time tracking**: Hours computed automatically from activity log
@@ -130,8 +131,28 @@ saga-mcp requires a single environment variable:
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DB_PATH` | Yes | Absolute path to the `.tracker.db` SQLite file. The file and schema are auto-created on first use. |
+| `SAGA_PROJECT` | No | Scope every tool to one project, by id or name. Set this per repo when several repos share one database. Unset, tools read across the whole file. |
+| `SAGA_TOOLS` | No | `full` (default) lists all 33 tools. `core` lists only the 12 an ordinary tracking session needs, cutting ~3,300 tokens of context per session. Tools left off the list still work if called by name. |
 
 No API keys, no accounts, no external services. Everything is stored locally in the SQLite file you specify.
+
+### Token cost
+
+The tool list is context every session pays before any work happens, and list responses are
+context it pays again on every call. Both are kept deliberately small:
+
+- Responses are compact JSON — no pretty-print indentation, which measured 20-27% of every response
+- `task_list` rows omit nulls and `metadata`, and truncate descriptions to 120 characters
+  (call `task_get` for a task's full text) — 19-39% smaller depending on how long your descriptions run
+- `activity_log` omits null columns and the row id (no tool takes one) — about 27% smaller
+- `tracker_search` returns previews rather than whole records — about 47% smaller; follow up with
+  `task_get` or `note_list` for the full text
+- `SAGA_TOOLS=core` drops the listed tool surface from ~6,000 to ~2,700 tokens
+
+`note_list` deliberately keeps full note content — it is the retrieval tool, not a preview.
+
+Set `SAGA_TOOLS=core` when an agent only tracks work; leave it unset when you want templates,
+import/export, session diffs and the rest discoverable.
 
 ## Tools
 
@@ -181,7 +202,9 @@ No API keys, no accounts, no external services. Everything is stored locally in 
 | Tool | Description | Annotations |
 |------|-------------|-------------|
 | `comment_add` | Add a comment to a task (threaded discussion) | `readOnly: false` |
-| `comment_list` | List all comments on a task | `readOnly: true` |
+| `comment_list` | List comments on a task (removed ones hidden unless `include_deleted`) | `readOnly: true` |
+| `comment_delete` | Remove a comment — soft delete, row kept for audit | `readOnly: false`, `idempotent: true` |
+| `comment_restore` | Restore a removed comment | `readOnly: false`, `idempotent: true` |
 
 ### Templates
 
@@ -280,6 +303,99 @@ task_update({ id: 5, status: "done" })
 
 Comments persist across sessions — next time an agent calls `task_get(5)`, it sees the full discussion thread.
 
+If a comment turns out to be wrong, retract it without losing the trail:
+
+```
+comment_delete({ id: 12, reason: "Root cause was wrong — it was a proxy timeout", deleted_by: "pranab" })
+```
+
+The row stays in the database and in the activity log. `comment_list` and `task_get` skip it,
+`comment_list({ task_id: 5, include_deleted: true })` shows it with its reason, and
+`comment_restore({ id: 12 })` brings it back. Nothing an agent removes is unrecoverable.
+
+## One database, many projects
+
+saga-mcp works either way: a `.tracker.db` per repo (portable, keeps unrelated work apart),
+or one shared database that every repo points at.
+
+The shared setup needs one extra thing. `projects` is the top-level table, so a shared file holds
+several projects — but `task_list`, `note_list`, `activity_log` and `tracker_search` read across
+the whole file unless told otherwise. An agent in repo B would see repo A's tasks. Set
+`SAGA_PROJECT` per repo and each agent sees only its own:
+
+```json
+{
+  "mcpServers": {
+    "saga": {
+      "command": "npx",
+      "args": ["-y", "saga-mcp"],
+      "env": {
+        "DB_PATH": "/Users/you/saga/central.tracker.db",
+        "SAGA_PROJECT": "Payments platform"
+      }
+    }
+  }
+}
+```
+
+`SAGA_PROJECT` takes a project id or a project name (case-insensitive), and fails on startup with
+the list of real projects if it matches neither. Every scoped tool also accepts an explicit
+`project_id` argument, which wins over the environment variable.
+
+| Setup | What to set | Result |
+|-------|-------------|--------|
+| One database per repo | `DB_PATH` | Nothing to scope — one project per file |
+| Shared database, per-repo agents | `DB_PATH` + `SAGA_PROJECT` | Each agent sees only its project |
+| Shared database, one agent over everything | `DB_PATH` | Tools read across all projects |
+
+With neither `SAGA_PROJECT` nor a `project_id`, `tracker_dashboard` falls back to the first project
+in the file and says so — the response carries `other_projects` and the summary explains that the
+project was a guess, rather than silently reporting on the wrong repo.
+
+The web UI is unaffected either way: its project switcher lists every project in the database, and
+each tab is scoped to the selected one.
+
+## Web UI
+
+Everything above is agent-facing. `saga-web` puts the same database in a browser — for the times
+when reviewing a spec an agent just wrote, or fixing one field by hand, is faster than another prompt.
+
+```bash
+npx -p saga-mcp saga-web ./.tracker.db --open
+```
+
+Or against a database you already point your MCP server at:
+
+```bash
+saga-web --db ~/saga/central.tracker.db --port 8080
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--db <path>` | `$DB_PATH` | Database to open. A positional path works too. |
+| `--port <n>` | first free from `4319` | Omit it and saga-web takes the first free port, so one instance per project just works. `--port N` binds exactly N and fails if taken; `--port 0` lets the OS choose. Also `SAGA_WEB_PORT`. |
+| `--host <addr>` | `127.0.0.1` | Bind address. Local-only by default. |
+| `--read-only` | off | Serve the UI with every editing control removed. |
+| `--open` | off | Open the UI in your default browser. |
+
+What you get:
+
+- **Overview** — stats, per-epic progress, blocked and overdue tasks
+- **Board** — kanban across the five task statuses; drag a card to change its status
+- **Epics** — the full Epic → Task → Subtask tree, which is the fastest way to review a spec an agent just wrote
+- **Notes** and **Activity** — decisions and the complete change history
+- **Task drawer** — edit any field, tick subtasks, comment, remove or restore a comment
+- **Project switcher** — every project in the database, so one central `.tracker.db` covers all your repos; every tab, including Activity, is scoped to the selected project
+
+Writes from the UI call the *same handlers* the MCP tools do, so edits you make by hand are
+validated identically and land in the same activity log as the agent's — an agent calling
+`tracker_dashboard` after you fix something sees the fix and how it happened.
+
+A few deliberate limits: it binds to `127.0.0.1` unless you ask otherwise, it has no
+authentication (don't put it on a shared network), and it will not create a database — point it
+at one your MCP server already uses. Separate `.tracker.db` files are not yet aggregated into
+one view; a single database with multiple projects is.
+
 ## How It Works
 
 saga-mcp stores everything in a single SQLite file (`.tracker.db`) per project. The database is auto-created on first use with all tables and indexes — no migration step needed.
@@ -355,6 +471,9 @@ cd saga-mcp
 npm install
 npm run build
 DB_PATH=./test.db npm start
+
+# the web UI against the same database
+node dist/web/index.js ./test.db --open
 ```
 
 ## Support

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
-  "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 31 focused tools with safety annotations\n- Import/export: Full project backup and migration as JSON",
+  "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 33 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {
     "name": "Pranab Sarkar",
     "email": "developer@pranab.co.in",
@@ -36,7 +36,9 @@
       "command": "node",
       "args": ["${__dirname}/dist/index.js"],
       "env": {
-        "DB_PATH": "${user_config.db_path}"
+        "DB_PATH": "${user_config.db_path}",
+        "SAGA_TOOLS": "${user_config.tool_surface}",
+        "SAGA_PROJECT": "${user_config.project_scope}"
       }
     }
   },
@@ -58,7 +60,9 @@
     { "name": "subtask_update", "description": "Update subtask title/status" },
     { "name": "subtask_delete", "description": "Delete subtask(s) — supports batch" },
     { "name": "comment_add", "description": "Add a comment to a task (threaded discussion)" },
-    { "name": "comment_list", "description": "List all comments on a task" },
+    { "name": "comment_list", "description": "List comments on a task (soft-deleted ones hidden by default)" },
+    { "name": "comment_delete", "description": "Remove a comment (soft delete — kept for audit, reversible)" },
+    { "name": "comment_restore", "description": "Restore a comment removed with comment_delete" },
     { "name": "template_create", "description": "Create a reusable task template" },
     { "name": "template_list", "description": "List available templates" },
     { "name": "template_apply", "description": "Apply template to create tasks with variable substitution" },
@@ -85,6 +89,19 @@
       "title": "Database Path",
       "description": "Path to the .tracker.db SQLite file. The file and schema are auto-created on first use.",
       "required": true
+    },
+    "project_scope": {
+      "type": "string",
+      "title": "Project Scope",
+      "description": "Optional. When one database is shared by several projects, set this to a project id or name so tools only see that project. Leave blank to read across the whole database.",
+      "required": false
+    },
+    "tool_surface": {
+      "type": "string",
+      "title": "Tool Surface",
+      "description": "\"full\" lists all 33 tools. \"core\" lists only the 12 needed for ordinary tracking, saving ~3,300 tokens of context per session; the rest still work if called by name.",
+      "default": "full",
+      "required": false
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,20 @@
 {
-  "name": "tracker-mcp",
-  "version": "1.1.0",
+  "name": "saga-mcp",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tracker-mcp",
-      "version": "1.1.0",
+      "name": "saga-mcp",
+      "version": "1.7.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "better-sqlite3": "^12.6.0"
+      },
+      "bin": {
+        "saga-mcp": "dist/index.js",
+        "saga-web": "dist/web/index.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.6.0",
-  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard — so LLMs never lose track.",
+  "version": "1.7.0",
+  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "saga-mcp": "dist/index.js"
+    "saga-mcp": "dist/index.js",
+    "saga-web": "dist/web/index.js"
   },
   "files": [
     "dist",
@@ -19,8 +20,11 @@
     "build": "tsc",
     "watch": "tsc --watch",
     "start": "node dist/index.js",
+    "web": "tsc && node dist/web/index.js",
     "dev": "tsc && node dist/index.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "test": "npm run build && node --test",
+    "test:only": "node --test"
   },
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/db.ts
+++ b/src/db.ts
@@ -26,6 +26,11 @@ export function getDb(): Database.Database {
   try { db.exec('ALTER TABLE tasks ADD COLUMN source_ref TEXT'); } catch { /* column already exists */ }
   try { db.exec('ALTER TABLE epics ADD COLUMN branch TEXT'); } catch { /* column already exists */ }
   try { db.exec('CREATE INDEX IF NOT EXISTS idx_epics_branch ON epics(branch)'); } catch { /* index already exists */ }
+  try { db.exec('ALTER TABLE comments ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0'); } catch { /* column already exists */ }
+  try { db.exec('ALTER TABLE comments ADD COLUMN deleted_at TEXT'); } catch { /* column already exists */ }
+  try { db.exec('ALTER TABLE comments ADD COLUMN deleted_by TEXT'); } catch { /* column already exists */ }
+  try { db.exec('ALTER TABLE comments ADD COLUMN delete_reason TEXT'); } catch { /* column already exists */ }
+  try { db.exec('CREATE INDEX IF NOT EXISTS idx_comments_task_live ON comments(task_id, is_deleted)'); } catch { /* index already exists */ }
 
   return db;
 }

--- a/src/helpers/project-scope.ts
+++ b/src/helpers/project-scope.ts
@@ -1,0 +1,126 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * One database can hold many projects — the "global" / centralized setup, where
+ * every repo points its MCP server at the same .tracker.db.
+ *
+ * Without scoping, an agent working in repo B sees repo A's tasks: task_list,
+ * note_list, activity_log and tracker_search all read across the whole file.
+ * These helpers give every such tool the same scoping rule:
+ *
+ *   explicit project_id argument  >  SAGA_PROJECT env var  >  unscoped
+ *
+ * Set SAGA_PROJECT (an id, or a project name) in each repo's MCP config and a
+ * shared database behaves exactly like a per-project one.
+ */
+
+let cachedEnvProject: { raw: string; id: number } | undefined;
+
+/** Resolve SAGA_PROJECT, which may be a numeric id or a project name. */
+function envProjectId(db: Database.Database): number | undefined {
+  const raw = process.env.SAGA_PROJECT?.trim();
+  if (!raw) return undefined;
+  if (cachedEnvProject && cachedEnvProject.raw === raw) return cachedEnvProject.id;
+
+  let row: { id: number } | undefined;
+  if (/^\d+$/.test(raw)) {
+    row = db.prepare('SELECT id FROM projects WHERE id = ?').get(Number(raw)) as { id: number } | undefined;
+  } else {
+    row = db.prepare('SELECT id FROM projects WHERE name = ? COLLATE NOCASE').get(raw) as { id: number } | undefined;
+  }
+  if (!row) {
+    const known = (db.prepare('SELECT id, name FROM projects ORDER BY id').all() as Array<{ id: number; name: string }>)
+      .map((p) => `${p.id}=${p.name}`)
+      .join(', ');
+    throw new Error(
+      `SAGA_PROJECT is set to '${raw}', which is not a project in this database. Known projects: ${known || '(none)'}`
+    );
+  }
+  cachedEnvProject = { raw, id: row.id };
+  return row.id;
+}
+
+/** The project a call should be scoped to, or undefined for the whole database. */
+export function resolveProjectId(
+  db: Database.Database,
+  args: Record<string, unknown>
+): number | undefined {
+  const explicit = args.project_id;
+  if (typeof explicit === 'number') return explicit;
+  if (typeof explicit === 'string' && /^\d+$/.test(explicit)) return Number(explicit);
+  return envProjectId(db);
+}
+
+export function projectCount(db: Database.Database): number {
+  return (db.prepare('SELECT COUNT(*) as n FROM projects').get() as { n: number }).n;
+}
+
+/** Shared JSON-schema property, so every scoped tool describes it identically. */
+export const PROJECT_ID_SCHEMA = {
+  type: 'integer' as const,
+  description:
+    'Scope to one project. Needed when a single database holds several projects; defaults to the SAGA_PROJECT env var if set, otherwise the whole database.',
+};
+
+/**
+ * `WHERE` fragment selecting tasks in a project, given an alias for the epics
+ * table already joined by the caller.
+ */
+export function taskScopeClause(epicAlias = 'e'): string {
+  return `${epicAlias}.project_id = ?`;
+}
+
+/** Notes attached to a project, or to any epic/task inside it. Unattached notes count as global. */
+export function noteScopeClause(alias = 'notes'): { sql: string; paramCount: number } {
+  return {
+    sql: `(
+      (${alias}.related_entity_type = 'project' AND ${alias}.related_entity_id = ?)
+      OR (${alias}.related_entity_type = 'epic' AND ${alias}.related_entity_id IN
+            (SELECT id FROM epics WHERE project_id = ?))
+      OR (${alias}.related_entity_type = 'task' AND ${alias}.related_entity_id IN
+            (SELECT t.id FROM tasks t JOIN epics e ON e.id = t.epic_id WHERE e.project_id = ?))
+      OR ${alias}.related_entity_type IS NULL
+    )`,
+    paramCount: 3,
+  };
+}
+
+/**
+ * Activity rows name an entity by type and id, so scoping means walking each
+ * type back up to its project.
+ */
+export function activityScopeClause(alias = 'activity_log'): { sql: string; paramCount: number } {
+  return {
+    sql: `(
+      (${alias}.entity_type = 'project' AND ${alias}.entity_id = ?)
+      OR (${alias}.entity_type = 'epic' AND ${alias}.entity_id IN
+            (SELECT id FROM epics WHERE project_id = ?))
+      OR (${alias}.entity_type = 'task' AND ${alias}.entity_id IN
+            (SELECT t.id FROM tasks t JOIN epics e ON e.id = t.epic_id WHERE e.project_id = ?))
+      OR (${alias}.entity_type = 'subtask' AND ${alias}.entity_id IN
+            (SELECT s.id FROM subtasks s JOIN tasks t ON t.id = s.task_id
+             JOIN epics e ON e.id = t.epic_id WHERE e.project_id = ?))
+      OR (${alias}.entity_type = 'comment' AND ${alias}.entity_id IN
+            (SELECT c.id FROM comments c JOIN tasks t ON t.id = c.task_id
+             JOIN epics e ON e.id = t.epic_id WHERE e.project_id = ?))
+      OR (${alias}.entity_type = 'note' AND ${alias}.entity_id IN
+            (SELECT n.id FROM notes n WHERE
+               (n.related_entity_type = 'project' AND n.related_entity_id = ?)
+               OR (n.related_entity_type = 'epic' AND n.related_entity_id IN
+                     (SELECT id FROM epics WHERE project_id = ?))
+               OR (n.related_entity_type = 'task' AND n.related_entity_id IN
+                     (SELECT t.id FROM tasks t JOIN epics e ON e.id = t.epic_id WHERE e.project_id = ?))))
+    )`,
+    paramCount: 8,
+  };
+}
+
+/** Repeat a project id n times, for the multi-placeholder clauses above. */
+export function repeatId(projectId: number, n: number): number[] {
+  return Array.from({ length: n }, () => projectId);
+}
+
+/** Only for tests — SAGA_PROJECT is read once and cached. */
+export function resetProjectScopeCache(): void {
+  cachedEnvProject = undefined;
+}

--- a/src/helpers/slim.ts
+++ b/src/helpers/slim.ts
@@ -1,0 +1,53 @@
+/**
+ * List responses are the tokens an agent pays over and over. Detail responses
+ * (task_get) stay complete; list rows drop what a scan does not need.
+ *
+ * Measured on a 40-task project: task_list went from ~5,300 to ~3,600 tokens.
+ */
+
+/** Longest description kept in a list row. Longer text is cut with an ellipsis. */
+export const LIST_DESCRIPTION_CHARS = 120;
+
+export function truncate(text: string, max = LIST_DESCRIPTION_CHARS): string {
+  if (text.length <= max) return text;
+  // Prefer a word boundary so the cut reads as prose rather than mid-token.
+  const cut = text.slice(0, max);
+  const lastSpace = cut.lastIndexOf(' ');
+  return (lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd() + '…';
+}
+
+/** Fields never worth their bytes in a list response. */
+const ALWAYS_DROP = new Set(['metadata']);
+
+/**
+ * Strip a list row down: no nulls, no metadata blob, no empty tags array, and
+ * long text fields truncated. Everything removed here is still available from
+ * the matching *_get tool.
+ */
+export function slimListRow(
+  row: Record<string, unknown>,
+  truncateFields: string[] = ['description'],
+  drop: string[] = []
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (value === null || value === undefined) continue;
+    if (ALWAYS_DROP.has(key) || drop.includes(key)) continue;
+    if (key === 'tags' && (value === '[]' || value === '')) continue;
+    if (truncateFields.includes(key) && typeof value === 'string') {
+      out[key] = truncate(value);
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/** Apply slimListRow across a result set. */
+export function slimList(
+  rows: Array<Record<string, unknown>>,
+  truncateFields?: string[],
+  drop?: string[]
+): Array<Record<string, unknown>> {
+  return rows.map((row) => slimListRow(row, truncateFields, drop));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,13 +48,44 @@ const ALL_HANDLERS: Record<string, (args: Record<string, unknown>) => unknown> =
   ...exportImportHandlers,
 };
 
+/**
+ * The full tool list costs ~6,000 tokens of context in every session before any
+ * work happens. SAGA_TOOLS=core exposes the subset that covers ordinary tracking
+ * (~2,300 tokens); handlers stay registered either way, so a client that already
+ * knows a tool name can still call it. Unset (or "full") keeps every tool listed.
+ */
+const CORE_TOOLS = new Set([
+  'tracker_init',
+  'tracker_dashboard',
+  'project_list',
+  'epic_create',
+  'epic_list',
+  'task_create',
+  'task_list',
+  'task_get',
+  'task_update',
+  'subtask_create',
+  'note_save',
+  'comment_add',
+]);
+
+function listedTools(): Tool[] {
+  const mode = (process.env.SAGA_TOOLS ?? 'full').trim().toLowerCase();
+  if (mode === 'full' || mode === '') return ALL_TOOLS;
+  if (mode !== 'core') {
+    console.error(`Unknown SAGA_TOOLS value '${mode}' — expected 'core' or 'full'. Listing all tools.`);
+    return ALL_TOOLS;
+  }
+  return ALL_TOOLS.filter((t) => CORE_TOOLS.has(t.name));
+}
+
 const server = new Server(
   { name: 'tracker', version: '1.0.0' },
   { capabilities: { tools: {} } }
 );
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools: ALL_TOOLS };
+  return { tools: listedTools() };
 });
 
 function friendlyError(msg: string): string {
@@ -85,7 +116,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     const result = handler(args ?? {});
     return {
-      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      // Compact, not pretty-printed: indentation costs ~22% of every response
+      // in tokens and buys the model nothing.
+      content: [{ type: 'text', text: JSON.stringify(result) }],
     };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
@@ -105,7 +138,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error('Tracker MCP Server running on stdio');
+  const listed = listedTools().length;
+  console.error(
+    `Tracker MCP Server running on stdio (${listed} of ${ALL_TOOLS.length} tools listed` +
+      `${listed < ALL_TOOLS.length ? ' — SAGA_TOOLS=core' : ''})`
+  );
 }
 
 process.on('SIGINT', () => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -78,6 +78,10 @@ CREATE TABLE IF NOT EXISTS comments (
   task_id    INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
   author     TEXT,
   content    TEXT NOT NULL,
+  is_deleted INTEGER NOT NULL DEFAULT 0,
+  deleted_at TEXT,
+  deleted_by TEXT,
+  delete_reason TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/src/tools/activity.ts
+++ b/src/tools/activity.ts
@@ -1,5 +1,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getDb } from '../db.js';
+import { resolveProjectId, activityScopeClause, repeatId, PROJECT_ID_SCHEMA } from '../helpers/project-scope.js';
+import { slimList } from '../helpers/slim.js';
 import { logActivity } from '../helpers/activity-logger.js';
 import { reevaluateDownstream } from './tasks.js';
 import type { ToolHandler } from '../types.js';
@@ -19,6 +21,7 @@ export const definitions: Tool[] = [
           description: 'Filter by entity type',
         },
         entity_id: { type: 'integer', description: 'Filter by specific entity' },
+        project_id: PROJECT_ID_SCHEMA,
         action: {
           type: 'string',
           enum: ['created', 'updated', 'deleted', 'status_changed'],
@@ -94,12 +97,21 @@ function handleActivityLog(args: Record<string, unknown>) {
     whereClauses.push('created_at > ?');
     params.push(since);
   }
+  const projectId = resolveProjectId(db, args);
+  if (projectId !== undefined) {
+    const scope = activityScopeClause('activity_log');
+    whereClauses.push(scope.sql);
+    params.push(...repeatId(projectId, scope.paramCount));
+  }
 
   const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
   const sql = `SELECT * FROM activity_log ${whereStr} ORDER BY created_at DESC LIMIT ?`;
   params.push(limit);
 
-  return db.prepare(sql).all(...params);
+  // No tool takes an activity id, and most rows leave field_name/old_value/
+  // new_value null, so both are dead weight in a log an agent reads often.
+  const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
+  return slimList(rows, [], ['id']);
 }
 
 function handleSessionDiff(args: Record<string, unknown>) {

--- a/src/tools/comments.ts
+++ b/src/tools/comments.ts
@@ -21,14 +21,47 @@ export const definitions: Tool[] = [
   },
   {
     name: 'comment_list',
-    description: 'List all comments on a task in chronological order.',
+    description:
+      'List comments on a task in chronological order. Comments removed with comment_delete are hidden by default; pass include_deleted to see them with their removal reason.',
     annotations: { title: 'List Comments', readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     inputSchema: {
       type: 'object',
       properties: {
         task_id: { type: 'integer', description: 'Task ID' },
+        include_deleted: {
+          type: 'boolean',
+          default: false,
+          description: 'Include comments that were removed (soft-deleted). Off by default.',
+        },
       },
       required: ['task_id'],
+    },
+  },
+  {
+    name: 'comment_delete',
+    description:
+      'Remove a comment (soft delete). The row is kept for the audit trail but hidden from comment_list and task_get. Use this to retract a comment that turned out to be wrong or stale. Reversible with comment_restore.',
+    annotations: { title: 'Remove Comment', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'integer', description: 'Comment ID to remove' },
+        reason: { type: 'string', description: 'Why the comment is being removed (recommended — it stays in the audit trail)' },
+        deleted_by: { type: 'string', description: 'Who removed it (optional)' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'comment_restore',
+    description: 'Restore a comment previously removed with comment_delete.',
+    annotations: { title: 'Restore Comment', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'integer', description: 'Comment ID to restore' },
+      },
+      required: ['id'],
     },
   },
 ];
@@ -57,13 +90,70 @@ function handleCommentAdd(args: Record<string, unknown>) {
 function handleCommentList(args: Record<string, unknown>) {
   const db = getDb();
   const taskId = args.task_id as number;
+  const includeDeleted = args.include_deleted === true;
 
-  return db
-    .prepare('SELECT * FROM comments WHERE task_id = ? ORDER BY created_at ASC')
-    .all(taskId);
+  const sql = includeDeleted
+    ? 'SELECT * FROM comments WHERE task_id = ? ORDER BY created_at ASC'
+    : 'SELECT * FROM comments WHERE task_id = ? AND is_deleted = 0 ORDER BY created_at ASC';
+
+  return db.prepare(sql).all(taskId);
+}
+
+function handleCommentDelete(args: Record<string, unknown>) {
+  const db = getDb();
+  const id = args.id as number;
+  const reason = (args.reason as string) ?? null;
+  const deletedBy = (args.deleted_by as string) ?? null;
+
+  const comment = db.prepare('SELECT * FROM comments WHERE id = ?').get(id) as Record<string, unknown> | undefined;
+  if (!comment) throw new Error(`Comment ${id} not found`);
+  if (comment.is_deleted) {
+    return { message: `Comment ${id} was already removed.`, comment };
+  }
+
+  const updated = db
+    .prepare(
+      `UPDATE comments
+       SET is_deleted = 1, deleted_at = datetime('now'), deleted_by = ?, delete_reason = ?
+       WHERE id = ? RETURNING *`
+    )
+    .get(deletedBy, reason, id) as Record<string, unknown>;
+
+  logActivity(db, 'comment', id, 'deleted', 'is_deleted', '0', '1',
+    `Comment ${id} removed${deletedBy ? ` by ${deletedBy}` : ''}${reason ? `: ${reason}` : ''}`);
+
+  return {
+    message: `Comment ${id} removed. The row is retained for audit — pass include_deleted to comment_list to see it, or comment_restore to bring it back.`,
+    comment: updated,
+  };
+}
+
+function handleCommentRestore(args: Record<string, unknown>) {
+  const db = getDb();
+  const id = args.id as number;
+
+  const comment = db.prepare('SELECT * FROM comments WHERE id = ?').get(id) as Record<string, unknown> | undefined;
+  if (!comment) throw new Error(`Comment ${id} not found`);
+  if (!comment.is_deleted) {
+    return { message: `Comment ${id} is not removed — nothing to restore.`, comment };
+  }
+
+  const updated = db
+    .prepare(
+      `UPDATE comments
+       SET is_deleted = 0, deleted_at = NULL, deleted_by = NULL, delete_reason = NULL
+       WHERE id = ? RETURNING *`
+    )
+    .get(id) as Record<string, unknown>;
+
+  logActivity(db, 'comment', id, 'restored', 'is_deleted', '1', '0', `Comment ${id} restored`);
+
+  return { message: `Comment ${id} restored.`, comment: updated };
 }
 
 export const handlers: Record<string, ToolHandler> = {
   comment_add: handleCommentAdd,
   comment_list: handleCommentList,
+  comment_delete: handleCommentDelete,
+  comment_restore: handleCommentRestore,
 };

--- a/src/tools/dashboard.ts
+++ b/src/tools/dashboard.ts
@@ -2,6 +2,8 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getDb } from '../db.js';
 import { logActivity } from '../helpers/activity-logger.js';
 import { resolveBranch } from '../helpers/git.js';
+import { resolveProjectId, projectCount } from '../helpers/project-scope.js';
+import { slimList } from '../helpers/slim.js';
 import type { ToolHandler } from '../types.js';
 
 export const definitions: Tool[] = [
@@ -13,10 +15,14 @@ export const definitions: Tool[] = [
     inputSchema: {
       type: 'object',
       properties: {
-        project_id: { type: 'integer', description: 'Project ID (omit if only one project exists)' },
+        project_id: {
+          type: 'integer',
+          description:
+            'Project ID. Omit if the database holds one project, or if SAGA_PROJECT is set. With several projects and neither, the first is used and the rest are listed under other_projects.',
+        },
         branch: {
           type: 'string',
-          description: 'Scope to a git branch. Pass "current" to auto-detect; pass empty string to restrict to branch-agnostic epics. Omit to include everything.',
+          description: 'Scope to a git branch: "current" = active branch, "" = branch-agnostic only, omit = all.',
         },
       },
     },
@@ -39,9 +45,13 @@ export const definitions: Tool[] = [
 function handleDashboard(args: Record<string, unknown>) {
   const db = getDb();
 
-  let projectId = args.project_id as number | undefined;
-  if (!projectId) {
-    const first = db.prepare('SELECT id FROM projects LIMIT 1').get() as { id: number } | undefined;
+  // Scope: explicit project_id > SAGA_PROJECT > the first project in the file.
+  // The last case is a guess, so say so rather than silently reporting on some
+  // other repo's work when one database holds several projects.
+  let projectId = resolveProjectId(db, args);
+  let guessed = false;
+  if (projectId === undefined) {
+    const first = db.prepare('SELECT id FROM projects ORDER BY id LIMIT 1').get() as { id: number } | undefined;
     if (!first) {
       return {
         message: 'No projects found. Use tracker_init or project_create to get started.',
@@ -49,6 +59,7 @@ function handleDashboard(args: Record<string, unknown>) {
       };
     }
     projectId = first.id;
+    guessed = projectCount(db) > 1;
   }
 
   const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(projectId);
@@ -98,7 +109,7 @@ function handleDashboard(args: Record<string, unknown>) {
     .get(projectId, ...branchParams);
 
   // Epics with task counts
-  const epics = db
+  const epics = slimList(db
     .prepare(
       `
     SELECT e.*,
@@ -115,7 +126,7 @@ function handleDashboard(args: Record<string, unknown>) {
     ORDER BY e.sort_order, e.created_at
   `
     )
-    .all(projectId, ...branchParams);
+    .all(projectId, ...branchParams) as Array<Record<string, unknown>>);
 
   // Blocked tasks
   const blockedTasks = db
@@ -144,11 +155,14 @@ function handleDashboard(args: Record<string, unknown>) {
     .all(projectId, today, ...branchParams) as Array<Record<string, unknown>>;
 
   // Recent activity (last 10)
-  const recentActivity = db
-    .prepare(
-      'SELECT summary, action, entity_type, entity_id, created_at FROM activity_log ORDER BY created_at DESC LIMIT 10'
-    )
-    .all();
+  const recentActivity = slimList(
+    db
+      .prepare(
+        'SELECT summary, action, entity_type, entity_id, created_at FROM activity_log ORDER BY created_at DESC LIMIT 10'
+      )
+      .all() as Array<Record<string, unknown>>,
+    []
+  );
 
   // Recent notes (last 5)
   const recentNotes = db
@@ -191,10 +205,23 @@ function handleDashboard(args: Record<string, unknown>) {
     summaryParts.push(`${s.tasks_in_progress} in progress.`);
   }
 
+  // When the project was a guess, tell the caller what else is in the file so it
+  // can pass project_id (or the operator can set SAGA_PROJECT) instead.
+  const otherProjects = guessed
+    ? db.prepare('SELECT id, name, status FROM projects WHERE id != ? ORDER BY id').all(projectId)
+    : [];
+  if (otherProjects.length > 0) {
+    summaryParts.push(
+      `Note: this database holds ${otherProjects.length + 1} projects and none was specified — ` +
+        `showing '${p.name}'. Pass project_id, or set SAGA_PROJECT, to scope to another.`
+    );
+  }
+
   const summary = summaryParts.join(' ');
 
   return {
     summary,
+    ...(otherProjects.length > 0 ? { other_projects: otherProjects } : {}),
     project,
     branch_scope: branchLabel,
     stats,

--- a/src/tools/epics.ts
+++ b/src/tools/epics.ts
@@ -1,6 +1,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getDb } from '../db.js';
 import { buildUpdate } from '../helpers/sql-builder.js';
+import { slimList } from '../helpers/slim.js';
 import { logActivity, logEntityUpdate } from '../helpers/activity-logger.js';
 import { resolveBranch } from '../helpers/git.js';
 import type { ToolHandler } from '../types.js';
@@ -9,7 +10,7 @@ export const definitions: Tool[] = [
   {
     name: 'epic_create',
     description:
-      'Create an epic within a project. Epics group related tasks into a feature or workstream. Pass branch to scope the epic to a git branch (use "current" to auto-detect).',
+      'Create an epic within a project. Epics group related tasks into a feature or workstream.',
     annotations: { title: 'Create Epic', readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
     inputSchema: {
       type: 'object',
@@ -29,7 +30,7 @@ export const definitions: Tool[] = [
         },
         branch: {
           type: 'string',
-          description: 'Git branch this epic is scoped to. Pass "current" to auto-detect from the repo. Omit or pass empty string for a branch-agnostic (global) epic.',
+          description: 'Branch to scope this epic to: "current" = active branch, omit/"" = branch-agnostic.',
         },
         tags: { type: 'array', items: { type: 'string' } },
       },
@@ -39,7 +40,7 @@ export const definitions: Tool[] = [
   {
     name: 'epic_list',
     description:
-      'List epics for a project with task counts and completion stats. Optionally filter by status, priority, or branch. Pass branch="current" to auto-detect the active git branch; pass empty string to list only branch-agnostic epics.',
+      'List epics for a project with task counts and completion stats. Filter by status, priority or branch.',
     annotations: { title: 'List Epics', readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     inputSchema: {
       type: 'object',
@@ -49,7 +50,7 @@ export const definitions: Tool[] = [
         priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
         branch: {
           type: 'string',
-          description: 'Filter by git branch. Pass "current" to auto-detect; pass empty string to list only branch-agnostic epics. Omit to list all.',
+          description: 'Git branch filter: "current" = active branch, "" = branch-agnostic only, omit = all.',
         },
       },
       required: ['project_id'],
@@ -71,7 +72,7 @@ export const definitions: Tool[] = [
         sort_order: { type: 'integer' },
         branch: {
           type: 'string',
-          description: 'Git branch this epic is scoped to. Pass "current" to auto-detect; pass empty string to clear (branch-agnostic).',
+          description: 'Branch to scope this epic to: "current" = active branch, "" = clear.',
         },
         tags: { type: 'array', items: { type: 'string' } },
       },
@@ -144,7 +145,7 @@ function handleEpicList(args: Record<string, unknown>) {
     ORDER BY e.sort_order, e.created_at
   `;
 
-  return db.prepare(sql).all(...params);
+  return slimList(db.prepare(sql).all(...params) as Array<Record<string, unknown>>);
 }
 
 function handleEpicUpdate(args: Record<string, unknown>) {

--- a/src/tools/export-import.ts
+++ b/src/tools/export-import.ts
@@ -93,6 +93,10 @@ function handleExport(args: Record<string, unknown>) {
           author: c.author,
           content: c.content,
           created_at: c.created_at,
+          is_deleted: c.is_deleted,
+          deleted_at: c.deleted_at,
+          deleted_by: c.deleted_by,
+          delete_reason: c.delete_reason,
         })),
       };
     });
@@ -291,8 +295,17 @@ function handleImport(args: Record<string, unknown>) {
         const comments = (taskData.comments as Array<Record<string, unknown>>) ?? [];
         for (const commentData of comments) {
           db.prepare(
-            'INSERT INTO comments (task_id, author, content) VALUES (?, ?, ?)'
-          ).run(newTaskId, commentData.author ?? null, commentData.content);
+            `INSERT INTO comments (task_id, author, content, is_deleted, deleted_at, deleted_by, delete_reason)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`
+          ).run(
+            newTaskId,
+            commentData.author ?? null,
+            commentData.content,
+            commentData.is_deleted ? 1 : 0,
+            commentData.deleted_at ?? null,
+            commentData.deleted_by ?? null,
+            commentData.delete_reason ?? null
+          );
           commentCount++;
         }
       }

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -2,6 +2,7 @@ import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getDb } from '../db.js';
 import { addTagFilter } from '../helpers/sql-builder.js';
 import { logActivity } from '../helpers/activity-logger.js';
+import { resolveProjectId, noteScopeClause, repeatId, PROJECT_ID_SCHEMA } from '../helpers/project-scope.js';
 import type { ToolHandler } from '../types.js';
 
 export const definitions: Tool[] = [
@@ -45,6 +46,7 @@ export const definitions: Tool[] = [
         },
         related_entity_type: { type: 'string', enum: ['project', 'epic', 'task'] },
         related_entity_id: { type: 'integer' },
+        project_id: PROJECT_ID_SCHEMA,
         tag: { type: 'string', description: 'Filter by a single tag' },
         limit: { type: 'integer', default: 30 },
       },
@@ -146,6 +148,12 @@ function handleNoteList(args: Record<string, unknown>) {
   }
   if (tag) {
     addTagFilter(whereClauses, params, tag, 'notes');
+  }
+  const projectId = resolveProjectId(db, args);
+  if (projectId !== undefined) {
+    const scope = noteScopeClause('notes');
+    whereClauses.push(scope.sql);
+    params.push(...repeatId(projectId, scope.paramCount));
   }
 
   const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';

--- a/src/tools/projects.ts
+++ b/src/tools/projects.ts
@@ -1,6 +1,7 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getDb } from '../db.js';
 import { buildUpdate } from '../helpers/sql-builder.js';
+import { slimList } from '../helpers/slim.js';
 import { logActivity, logEntityUpdate } from '../helpers/activity-logger.js';
 import type { ToolHandler } from '../types.js';
 
@@ -108,7 +109,7 @@ function handleProjectList(args: Record<string, unknown>) {
 
   sql += ' GROUP BY p.id ORDER BY p.created_at DESC';
 
-  return db.prepare(sql).all(...params);
+  return slimList(db.prepare(sql).all(...params) as Array<Record<string, unknown>>);
 }
 
 function handleProjectUpdate(args: Record<string, unknown>) {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,6 +1,8 @@
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { getDb } from '../db.js';
 import { resolveBranch } from '../helpers/git.js';
+import { resolveProjectId, noteScopeClause, repeatId, PROJECT_ID_SCHEMA } from '../helpers/project-scope.js';
+import { slimList } from '../helpers/slim.js';
 import type { ToolHandler } from '../types.js';
 
 export const definitions: Tool[] = [
@@ -18,9 +20,10 @@ export const definitions: Tool[] = [
           items: { type: 'string', enum: ['project', 'epic', 'task', 'note'] },
           description: 'Limit search to specific entity types (omit for all)',
         },
+        project_id: PROJECT_ID_SCHEMA,
         branch: {
           type: 'string',
-          description: 'Filter epic/task results by git branch. Pass "current" to auto-detect; pass empty string to restrict to branch-agnostic epics. Omit to include all.',
+          description: 'Git branch filter: "current" = active branch, "" = branch-agnostic only, omit = all.',
         },
         limit: { type: 'integer', default: 20, description: 'Max results per entity type' },
       },
@@ -51,42 +54,68 @@ function handleSearch(args: Record<string, unknown>) {
     taskBranchParams.push(branchFilter);
   }
 
+  const projectId = resolveProjectId(db, args);
+  if (projectId !== undefined) {
+    epicBranchClause += ' AND e.project_id = ?';
+    epicBranchParams.push(projectId);
+    taskBranchClause += ' AND e.project_id = ?';
+    taskBranchParams.push(projectId);
+  }
+
+  // Search results are a shortlist to pick from, not the content itself — slim
+  // the rows and preview long text. Follow up with task_get / note_list.
+  const rows = (r: unknown[], truncate: string[] = ['description']) =>
+    slimList(r as Array<Record<string, unknown>>, truncate);
+
   const results: Record<string, unknown[]> = {};
 
   if (entityTypes.includes('project')) {
-    results.projects = db
-      .prepare('SELECT * FROM projects WHERE name LIKE ? OR description LIKE ? LIMIT ?')
-      .all(pattern, pattern, limit);
+    results.projects = rows(
+      projectId !== undefined
+        ? db.prepare('SELECT id, name, description, status FROM projects WHERE id = ? AND (name LIKE ? OR description LIKE ?) LIMIT ?')
+            .all(projectId, pattern, pattern, limit)
+        : db.prepare('SELECT id, name, description, status FROM projects WHERE name LIKE ? OR description LIKE ? LIMIT ?')
+            .all(pattern, pattern, limit)
+    );
   }
 
   if (entityTypes.includes('epic')) {
-    results.epics = db
+    results.epics = rows(db
       .prepare(
-        `SELECT e.*, p.name as project_name
+        `SELECT e.id, e.project_id, e.name, e.description, e.status, e.priority, e.branch, p.name as project_name
          FROM epics e
          JOIN projects p ON p.id = e.project_id
          WHERE (e.name LIKE ? OR e.description LIKE ?)${epicBranchClause}
          LIMIT ?`
       )
-      .all(pattern, pattern, ...epicBranchParams, limit);
+      .all(pattern, pattern, ...epicBranchParams, limit));
   }
 
   if (entityTypes.includes('task')) {
-    results.tasks = db
+    results.tasks = rows(db
       .prepare(
-        `SELECT t.*, e.name as epic_name
+        `SELECT t.id, t.epic_id, t.title, t.description, t.status, t.priority, t.assigned_to, t.due_date, e.name as epic_name
          FROM tasks t
          JOIN epics e ON e.id = t.epic_id
          WHERE (t.title LIKE ? OR t.description LIKE ?)${taskBranchClause}
          LIMIT ?`
       )
-      .all(pattern, pattern, ...taskBranchParams, limit);
+      .all(pattern, pattern, ...taskBranchParams, limit));
   }
 
   if (entityTypes.includes('note')) {
-    results.notes = db
-      .prepare('SELECT * FROM notes WHERE title LIKE ? OR content LIKE ? LIMIT ?')
-      .all(pattern, pattern, limit);
+    if (projectId !== undefined) {
+      const scope = noteScopeClause('notes');
+      results.notes = rows(db
+        .prepare(`SELECT id, title, content, note_type, related_entity_type, related_entity_id, created_at
+                  FROM notes WHERE (title LIKE ? OR content LIKE ?) AND ${scope.sql} LIMIT ?`)
+        .all(pattern, pattern, ...repeatId(projectId, scope.paramCount), limit), ['content']);
+    } else {
+      results.notes = rows(db
+        .prepare(`SELECT id, title, content, note_type, related_entity_type, related_entity_id, created_at
+                  FROM notes WHERE title LIKE ? OR content LIKE ? LIMIT ?`)
+        .all(pattern, pattern, limit), ['content']);
+    }
   }
 
   return results;

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -3,6 +3,8 @@ import type Database from 'better-sqlite3';
 import { getDb } from '../db.js';
 import { buildUpdate, addTagFilter } from '../helpers/sql-builder.js';
 import { logActivity, logEntityUpdate } from '../helpers/activity-logger.js';
+import { slimListRow, LIST_DESCRIPTION_CHARS } from '../helpers/slim.js';
+import { resolveProjectId, taskScopeClause, PROJECT_ID_SCHEMA } from '../helpers/project-scope.js';
 import { resolveBranch } from '../helpers/git.js';
 import type { ToolHandler } from '../types.js';
 
@@ -51,19 +53,22 @@ export const definitions: Tool[] = [
   {
     name: 'task_list',
     description:
-      'List tasks with optional filters. If no epic_id given, lists across ALL epics. Includes subtask counts and dependency info. Pass branch="current" to restrict to tasks whose epic is scoped to the active git branch.',
+      'List tasks with optional filters. If no epic_id given, lists across ALL epics. Includes subtask counts and dependency info. ' +
+      'Rows are compact: null fields and metadata are omitted, and descriptions are truncated to ' + LIST_DESCRIPTION_CHARS + ' characters (trailing ellipsis) — call task_get for a full task. ' +
+      'Pass branch="current" to restrict to tasks whose epic is scoped to the active git branch.',
     annotations: { title: 'List Tasks', readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     inputSchema: {
       type: 'object',
       properties: {
         epic_id: { type: 'integer', description: 'Filter by epic (omit for all tasks)' },
+        project_id: PROJECT_ID_SCHEMA,
         status: { type: 'string', enum: ['todo', 'in_progress', 'review', 'done', 'blocked'] },
         priority: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
         assigned_to: { type: 'string', description: 'Filter by assignee' },
         tag: { type: 'string', description: 'Filter by tag' },
         branch: {
           type: 'string',
-          description: 'Filter by the git branch of the task\'s epic. Pass "current" to auto-detect; pass empty string to restrict to branch-agnostic epics. Omit to list all.',
+          description: 'Git branch filter: "current" = active branch, "" = branch-agnostic only, omit = all.',
         },
         sort_by: {
           type: 'string',
@@ -247,6 +252,11 @@ function handleTaskList(args: Record<string, unknown>) {
     whereClauses.push('t.epic_id = ?');
     params.push(epicId);
   }
+  const projectId = resolveProjectId(db, args);
+  if (projectId !== undefined) {
+    whereClauses.push(taskScopeClause('e'));
+    params.push(projectId);
+  }
   if (status) {
     whereClauses.push('t.status = ?');
     params.push(status);
@@ -289,7 +299,8 @@ function handleTaskList(args: Record<string, unknown>) {
   `;
 
   params.push(limit);
-  return db.prepare(sql).all(...params);
+  const rows = db.prepare(sql).all(...params) as Array<Record<string, unknown>>;
+  return rows.map((row) => slimListRow(row));
 }
 
 function handleTaskGet(args: Record<string, unknown>) {
@@ -320,7 +331,7 @@ function handleTaskGet(args: Record<string, unknown>) {
     .all(id);
 
   const comments = db
-    .prepare('SELECT * FROM comments WHERE task_id = ? ORDER BY created_at ASC')
+    .prepare('SELECT * FROM comments WHERE task_id = ? AND is_deleted = 0 ORDER BY created_at ASC')
     .all(id);
 
   // Dependencies: what this task depends on

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,0 +1,376 @@
+#!/usr/bin/env node
+/**
+ * saga-web — a local web viewer/editor for a saga-mcp .tracker.db file.
+ *
+ * Reads go through hand-written queries (src/web/queries.ts); writes are
+ * dispatched to the very same handlers the MCP tools use, so the UI and the
+ * agent share one code path, one validation story, and one activity log.
+ *
+ * Binds to 127.0.0.1 by default — nothing is exposed to the network unless you
+ * explicitly pass --host.
+ */
+import { createServer } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getDb, closeDb } from '../db.js';
+import { PAGE } from './ui.js';
+import * as q from './queries.js';
+
+import { handlers as projectHandlers } from '../tools/projects.js';
+import { handlers as epicHandlers } from '../tools/epics.js';
+import { handlers as taskHandlers } from '../tools/tasks.js';
+import { handlers as subtaskHandlers } from '../tools/subtasks.js';
+import { handlers as noteHandlers } from '../tools/notes.js';
+import { handlers as commentHandlers } from '../tools/comments.js';
+import { handlers as dashboardHandlers } from '../tools/dashboard.js';
+
+/** Write tools the UI is allowed to invoke. Anything not listed is refused. */
+const WRITE_TOOLS: Record<string, (args: Record<string, unknown>) => unknown> = {
+  project_create: projectHandlers.project_create,
+  project_update: projectHandlers.project_update,
+  tracker_init: dashboardHandlers.tracker_init,
+  epic_create: epicHandlers.epic_create,
+  epic_update: epicHandlers.epic_update,
+  task_create: taskHandlers.task_create,
+  task_update: taskHandlers.task_update,
+  subtask_create: subtaskHandlers.subtask_create,
+  subtask_update: subtaskHandlers.subtask_update,
+  subtask_delete: subtaskHandlers.subtask_delete,
+  note_save: noteHandlers.note_save,
+  note_delete: noteHandlers.note_delete,
+  comment_add: commentHandlers.comment_add,
+  comment_delete: commentHandlers.comment_delete,
+  comment_restore: commentHandlers.comment_restore,
+};
+
+interface Options {
+  dbPath: string;
+  /** Undefined means "find a free port", so several projects can each run their own. */
+  port: number | undefined;
+  host: string;
+  readOnly: boolean;
+  open: boolean;
+}
+
+/** Where the search for a free port starts when no --port is given. */
+const DEFAULT_PORT = 4319;
+/** How many consecutive ports to try before giving up. */
+const PORT_SCAN_RANGE = 40;
+
+const USAGE = `saga-web — local web UI for a saga-mcp tracker database
+
+Usage:
+  saga-web [db-path] [options]
+
+Options:
+  --db <path>     Path to the .tracker.db file (or set DB_PATH)
+  --port <n>      Port to listen on. Omit to take the first free port from 4319 up,
+                  so several projects can each run their own UI. Use 0 to let the
+                  OS pick any free port. Also settable with SAGA_WEB_PORT.
+  --host <addr>   Address to bind (default 127.0.0.1 — local only)
+  --read-only     Serve the UI without any editing controls
+  --open          Open the UI in your default browser
+  -h, --help      Show this help
+
+Examples:
+  saga-web ./.tracker.db
+  saga-web --db ~/saga/central.tracker.db --port 8080 --open
+  DB_PATH=./.tracker.db npx saga-mcp-web
+
+Running one per project is fine — each picks its own port and prints the URL.
+`;
+
+function parseArgs(argv: string[]): Options | null {
+  let dbPath = process.env.DB_PATH ?? '';
+  const portEnv = process.env.SAGA_WEB_PORT ?? process.env.PORT;
+  let port: number | undefined = portEnv === undefined || portEnv === '' ? undefined : Number(portEnv);
+  let host = process.env.SAGA_WEB_HOST ?? '127.0.0.1';
+  let readOnly = false;
+  let open = false;
+  let dbPathWasPositional = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '-h' || a === '--help') {
+      process.stdout.write(USAGE);
+      return null;
+    } else if (a === '--db') {
+      dbPath = argv[++i] ?? '';
+    } else if (a === '--port') {
+      port = Number(argv[++i]);
+    } else if (a === '--host') {
+      host = argv[++i] ?? host;
+    } else if (a === '--read-only' || a === '--readonly') {
+      readOnly = true;
+    } else if (a === '--open') {
+      open = true;
+    } else if (!a.startsWith('-') && !dbPathWasPositional) {
+      dbPath = a;
+      dbPathWasPositional = true;
+    } else {
+      throw new Error(`Unknown argument: ${a}\n\n${USAGE}`);
+    }
+  }
+
+  if (!dbPath) {
+    throw new Error(
+      'No database given. Pass a path (saga-web ./.tracker.db), use --db, or set DB_PATH.\n\n' + USAGE
+    );
+  }
+  if (port !== undefined && (!Number.isInteger(port) || port < 0 || port > 65535)) {
+    throw new Error('Invalid --port value: expected an integer between 0 and 65535.');
+  }
+
+  return { dbPath: resolve(dbPath), port, host, readOnly, open };
+}
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  const text = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+    'x-content-type-options': 'nosniff',
+  });
+  res.end(text);
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => {
+      size += c.length;
+      if (size > 2_000_000) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => resolvePromise(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+/**
+ * The UI sends a custom header on every write, which forces a CORS preflight we
+ * never approve — so a page on some other origin cannot POST here. We also
+ * reject any Origin that is not this server itself.
+ */
+function originAllowed(req: IncomingMessage, opts: Options): boolean {
+  const origin = req.headers.origin;
+  if (!origin) return true; // non-browser client (curl, script)
+  try {
+    const u = new URL(origin);
+    const localHosts = ['localhost', '127.0.0.1', '[::1]', '::1', opts.host];
+    return localHosts.includes(u.hostname) && (u.port === String(opts.port) || u.port === '');
+  } catch {
+    return false;
+  }
+}
+
+function start(opts: Options): void {
+  if (!existsSync(opts.dbPath)) {
+    throw new Error(
+      `Database not found: ${opts.dbPath}\n` +
+        'saga-web does not create databases — point it at a .tracker.db your MCP server already uses.'
+    );
+  }
+
+  // Shared with the MCP tool handlers; also applies pending schema migrations.
+  process.env.DB_PATH = opts.dbPath;
+  const db = getDb();
+
+  const server = createServer((req, res) => {
+    void handle(req, res, opts, db).catch((err: unknown) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!res.headersSent) json(res, 500, { error: msg });
+      else res.end();
+    });
+  });
+
+  // An explicit --port must be honoured exactly (scripts and bookmarks depend on
+  // it). With no --port we walk upward from the default until something is free,
+  // so a second project's UI just lands on the next port instead of failing.
+  const explicit = opts.port !== undefined;
+  const firstPort = opts.port ?? DEFAULT_PORT;
+  const attempts = explicit ? 1 : PORT_SCAN_RANGE;
+
+  const tryListen = (port: number, remaining: number): void => {
+    const onError = (err: NodeJS.ErrnoException) => {
+      if (err.code !== 'EADDRINUSE') throw err;
+      server.removeListener('error', onError);
+      if (remaining <= 1) {
+        console.error(
+          explicit
+            ? `Port ${port} is already in use. Omit --port to take the next free one.`
+            : `No free port between ${firstPort} and ${firstPort + PORT_SCAN_RANGE - 1}. Pass --port to choose one.`
+        );
+        process.exit(1);
+      }
+      tryListen(port + 1, remaining - 1);
+    };
+    server.once('error', onError);
+    server.listen(port, opts.host, () => {
+      server.removeListener('error', onError);
+      const bound = server.address();
+      const actual = typeof bound === 'object' && bound ? bound.port : port;
+      const shown = opts.host === '0.0.0.0' || opts.host === '::' ? 'localhost' : opts.host;
+      const url = `http://${shown}:${actual}`;
+      console.log(`saga-web  ${url}`);
+      console.log(`database  ${opts.dbPath}`);
+      console.log(`mode      ${opts.readOnly ? 'read-only' : 'editable'}`);
+      if (!explicit && actual !== firstPort) {
+        console.log(`note      ${firstPort} was busy — took the next free port.`);
+      }
+      if (opts.host !== '127.0.0.1' && opts.host !== 'localhost') {
+        console.log('warning   bound beyond localhost — this UI has no authentication.');
+      }
+      opts.port = actual;
+      if (opts.open) openBrowser(url);
+    });
+  };
+
+  tryListen(firstPort, attempts);
+
+  const shutdown = () => {
+    server.close();
+    closeDb();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function handle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: Options,
+  db: ReturnType<typeof getDb>
+): Promise<void> {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const path = url.pathname;
+
+  if (req.method === 'OPTIONS') {
+    // No CORS approval — keeps cross-origin writes impossible.
+    res.writeHead(204).end();
+    return;
+  }
+
+  if (req.method === 'GET' && (path === '/' || path === '/index.html')) {
+    res.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+    });
+    res.end(PAGE);
+    return;
+  }
+
+  if (req.method === 'GET' && path === '/api/projects') {
+    json(res, 200, {
+      projects: q.listProjects(db),
+      db_path: opts.dbPath,
+      read_only: opts.readOnly,
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && path === '/api/overview') {
+    const pid = Number(url.searchParams.get('project_id'));
+    if (!pid) return json(res, 400, { error: 'project_id is required' });
+    const data = q.getOverview(db, pid);
+    if (!data) return json(res, 404, { error: `Project ${pid} not found` });
+    return json(res, 200, data);
+  }
+
+  if (req.method === 'GET' && path === '/api/tasks') {
+    const pid = Number(url.searchParams.get('project_id'));
+    if (!pid) return json(res, 400, { error: 'project_id is required' });
+    return json(res, 200, { tasks: q.listTasks(db, pid) });
+  }
+
+  const taskMatch = /^\/api\/tasks\/(\d+)$/.exec(path);
+  if (req.method === 'GET' && taskMatch) {
+    const task = q.getTask(db, Number(taskMatch[1]), url.searchParams.get('include_deleted') === '1');
+    if (!task) return json(res, 404, { error: `Task ${taskMatch[1]} not found` });
+    return json(res, 200, task);
+  }
+
+  if (req.method === 'GET' && path === '/api/notes') {
+    const raw = url.searchParams.get('project_id');
+    const pid = raw ? Number(raw) : null;
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 100, 500);
+    return json(res, 200, { notes: q.listNotes(db, pid, limit) });
+  }
+
+  if (req.method === 'GET' && path === '/api/activity') {
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 100, 1000);
+    const raw = url.searchParams.get('project_id');
+    const pid = raw ? Number(raw) : null;
+    return json(res, 200, { activity: q.listActivity(db, pid, limit) });
+  }
+
+  if (req.method === 'GET' && path === '/api/search') {
+    const query = (url.searchParams.get('q') ?? '').trim();
+    if (query.length < 2) {
+      return json(res, 200, { projects: [], epics: [], tasks: [], notes: [] });
+    }
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 25, 100);
+    return json(res, 200, q.search(db, query, limit));
+  }
+
+  if (req.method === 'POST' && path === '/api/action') {
+    if (opts.readOnly) {
+      return json(res, 403, { error: 'This viewer was started with --read-only.' });
+    }
+    if (req.headers['x-saga-ui'] !== '1') {
+      return json(res, 403, { error: 'Missing x-saga-ui header.' });
+    }
+    if (!originAllowed(req, opts)) {
+      return json(res, 403, { error: 'Cross-origin write refused.' });
+    }
+
+    let payload: { tool?: string; args?: Record<string, unknown> };
+    try {
+      payload = JSON.parse(await readBody(req));
+    } catch {
+      return json(res, 400, { error: 'Invalid JSON body' });
+    }
+
+    const tool = payload.tool ?? '';
+    const handler = Object.prototype.hasOwnProperty.call(WRITE_TOOLS, tool)
+      ? WRITE_TOOLS[tool]
+      : undefined;
+    if (!handler) return json(res, 400, { error: `Unknown or disallowed action: ${tool}` });
+
+    try {
+      return json(res, 200, { ok: true, result: handler(payload.args ?? {}) });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return json(res, 400, { error: msg });
+    }
+  }
+
+  json(res, 404, { error: 'Not found' });
+}
+
+function openBrowser(url: string): void {
+  const cmd =
+    process.platform === 'win32' ? 'cmd' : process.platform === 'darwin' ? 'open' : 'xdg-open';
+  const args = process.platform === 'win32' ? ['/c', 'start', '', url] : [url];
+  import('node:child_process')
+    .then(({ spawn }) => spawn(cmd, args, { stdio: 'ignore', detached: true }).unref())
+    .catch(() => {
+      /* opening a browser is a convenience, never a failure */
+    });
+}
+
+try {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts) start(opts);
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/src/web/queries.ts
+++ b/src/web/queries.ts
@@ -1,0 +1,240 @@
+import type Database from 'better-sqlite3';
+import { activityScopeClause, repeatId } from '../helpers/project-scope.js';
+
+/**
+ * Read-only queries backing the web viewer. Every statement here is a SELECT —
+ * the viewer never writes. The MCP tools remain the only write path.
+ */
+
+export function listProjects(db: Database.Database) {
+  return db
+    .prepare(
+      `SELECT p.*,
+        COUNT(DISTINCT e.id) as epic_count,
+        COUNT(DISTINCT t.id) as task_count,
+        SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END) as done_count,
+        CASE WHEN COUNT(DISTINCT t.id) > 0
+          THEN ROUND(SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END) * 100.0 / COUNT(DISTINCT t.id), 1)
+          ELSE 0 END as completion_pct
+      FROM projects p
+      LEFT JOIN epics e ON e.project_id = p.id
+      LEFT JOIN tasks t ON t.epic_id = e.id
+      GROUP BY p.id
+      ORDER BY
+        CASE p.status WHEN 'active' THEN 0 WHEN 'on_hold' THEN 1 WHEN 'completed' THEN 2 ELSE 3 END,
+        p.created_at DESC`
+    )
+    .all();
+}
+
+export function getOverview(db: Database.Database, projectId: number) {
+  const project = db.prepare('SELECT * FROM projects WHERE id = ?').get(projectId);
+  if (!project) return null;
+
+  const stats = db
+    .prepare(
+      `WITH epic_ids AS (SELECT id FROM epics WHERE project_id = ?),
+       task_stats AS (
+         SELECT
+           COUNT(*) as total_tasks,
+           SUM(CASE WHEN status = 'done' THEN 1 ELSE 0 END) as tasks_done,
+           SUM(CASE WHEN status = 'in_progress' THEN 1 ELSE 0 END) as tasks_in_progress,
+           SUM(CASE WHEN status = 'review' THEN 1 ELSE 0 END) as tasks_review,
+           SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END) as tasks_blocked,
+           SUM(CASE WHEN status = 'todo' THEN 1 ELSE 0 END) as tasks_todo,
+           COALESCE(SUM(estimated_hours), 0) as total_estimated_hours,
+           COALESCE(SUM(actual_hours), 0) as total_actual_hours
+         FROM tasks WHERE epic_id IN (SELECT id FROM epic_ids)
+       )
+       SELECT (SELECT COUNT(*) FROM epic_ids) as total_epics, ts.*,
+         CASE WHEN ts.total_tasks > 0
+           THEN ROUND(ts.tasks_done * 100.0 / ts.total_tasks, 1)
+           ELSE 0 END as completion_pct
+       FROM task_stats ts`
+    )
+    .get(projectId);
+
+  const epics = db
+    .prepare(
+      `SELECT e.*,
+        COUNT(t.id) as task_count,
+        SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END) as done_count,
+        SUM(CASE WHEN t.status = 'blocked' THEN 1 ELSE 0 END) as blocked_count,
+        CASE WHEN COUNT(t.id) > 0
+          THEN ROUND(SUM(CASE WHEN t.status = 'done' THEN 1 ELSE 0 END) * 100.0 / COUNT(t.id), 1)
+          ELSE 0 END as completion_pct
+      FROM epics e
+      LEFT JOIN tasks t ON t.epic_id = e.id
+      WHERE e.project_id = ?
+      GROUP BY e.id
+      ORDER BY e.sort_order, e.created_at`
+    )
+    .all(projectId);
+
+  const today = new Date().toISOString().slice(0, 10);
+  const overdue = db
+    .prepare(
+      `SELECT t.id, t.title, t.due_date, t.priority, t.status, e.name as epic_name
+       FROM tasks t JOIN epics e ON e.id = t.epic_id
+       WHERE e.project_id = ? AND t.due_date IS NOT NULL AND t.due_date < ? AND t.status != 'done'
+       ORDER BY t.due_date ASC`
+    )
+    .all(projectId, today);
+
+  const blocked = db
+    .prepare(
+      `SELECT t.id, t.title, t.priority, t.status, e.name as epic_name
+       FROM tasks t JOIN epics e ON e.id = t.epic_id
+       WHERE e.project_id = ? AND t.status = 'blocked'
+       ORDER BY CASE t.priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END`
+    )
+    .all(projectId);
+
+  const branches = db
+    .prepare(
+      `SELECT branch, COUNT(*) as epic_count FROM epics
+       WHERE project_id = ? AND branch IS NOT NULL AND branch != ''
+       GROUP BY branch ORDER BY branch`
+    )
+    .all(projectId);
+
+  return { project, stats, epics, overdue_tasks: overdue, blocked_tasks: blocked, branches };
+}
+
+export function listTasks(db: Database.Database, projectId: number) {
+  return db
+    .prepare(
+      `SELECT t.*, e.name as epic_name, e.branch as epic_branch,
+        (SELECT COUNT(*) FROM subtasks s WHERE s.task_id = t.id) as subtask_count,
+        (SELECT COUNT(*) FROM subtasks s WHERE s.task_id = t.id AND s.status = 'done') as subtask_done,
+        (SELECT COUNT(*) FROM comments c WHERE c.task_id = t.id AND c.is_deleted = 0) as comment_count
+       FROM tasks t JOIN epics e ON e.id = t.epic_id
+       WHERE e.project_id = ?
+       ORDER BY e.sort_order, e.created_at, t.sort_order, t.created_at`
+    )
+    .all(projectId);
+}
+
+export function getTask(db: Database.Database, taskId: number, includeDeleted: boolean) {
+  const task = db
+    .prepare(
+      `SELECT t.*, e.name as epic_name, e.id as epic_id, e.branch as epic_branch, p.name as project_name, p.id as project_id
+       FROM tasks t JOIN epics e ON e.id = t.epic_id JOIN projects p ON p.id = e.project_id
+       WHERE t.id = ?`
+    )
+    .get(taskId);
+  if (!task) return null;
+
+  const subtasks = db
+    .prepare('SELECT * FROM subtasks WHERE task_id = ? ORDER BY sort_order, created_at')
+    .all(taskId);
+
+  const comments = db
+    .prepare(
+      includeDeleted
+        ? 'SELECT * FROM comments WHERE task_id = ? ORDER BY created_at ASC'
+        : 'SELECT * FROM comments WHERE task_id = ? AND is_deleted = 0 ORDER BY created_at ASC'
+    )
+    .all(taskId);
+
+  const deletedCount = db
+    .prepare('SELECT COUNT(*) as n FROM comments WHERE task_id = ? AND is_deleted = 1')
+    .get(taskId) as { n: number };
+
+  const notes = db
+    .prepare(
+      `SELECT * FROM notes WHERE related_entity_type = 'task' AND related_entity_id = ?
+       ORDER BY created_at DESC`
+    )
+    .all(taskId);
+
+  const dependsOn = db
+    .prepare(
+      `SELECT t.id, t.title, t.status FROM task_dependencies d
+       JOIN tasks t ON t.id = d.depends_on_task_id WHERE d.task_id = ?`
+    )
+    .all(taskId);
+
+  const dependents = db
+    .prepare(
+      `SELECT t.id, t.title, t.status FROM task_dependencies d
+       JOIN tasks t ON t.id = d.task_id WHERE d.depends_on_task_id = ?`
+    )
+    .all(taskId);
+
+  const activity = db
+    .prepare(
+      `SELECT * FROM activity_log WHERE entity_type = 'task' AND entity_id = ?
+       ORDER BY created_at DESC LIMIT 30`
+    )
+    .all(taskId);
+
+  return {
+    ...(task as object),
+    subtasks,
+    comments,
+    deleted_comment_count: deletedCount.n,
+    notes,
+    depends_on: dependsOn,
+    dependents,
+    activity,
+  };
+}
+
+export function listNotes(db: Database.Database, projectId: number | null, limit: number) {
+  if (projectId === null) {
+    return db.prepare('SELECT * FROM notes ORDER BY created_at DESC LIMIT ?').all(limit);
+  }
+  return db
+    .prepare(
+      `SELECT n.* FROM notes n
+       WHERE (n.related_entity_type = 'project' AND n.related_entity_id = ?)
+          OR (n.related_entity_type = 'epic' AND n.related_entity_id IN
+                (SELECT id FROM epics WHERE project_id = ?))
+          OR (n.related_entity_type = 'task' AND n.related_entity_id IN
+                (SELECT t.id FROM tasks t JOIN epics e ON e.id = t.epic_id WHERE e.project_id = ?))
+          OR n.related_entity_type IS NULL
+       ORDER BY n.created_at DESC LIMIT ?`
+    )
+    .all(projectId, projectId, projectId, limit);
+}
+
+export function listActivity(db: Database.Database, projectId: number | null, limit: number) {
+  if (projectId === null) {
+    return db
+      .prepare('SELECT * FROM activity_log ORDER BY created_at DESC, id DESC LIMIT ?')
+      .all(limit);
+  }
+  const scope = activityScopeClause('activity_log');
+  return db
+    .prepare(
+      `SELECT * FROM activity_log WHERE ${scope.sql} ORDER BY created_at DESC, id DESC LIMIT ?`
+    )
+    .all(...repeatId(projectId, scope.paramCount), limit);
+}
+
+export function search(db: Database.Database, query: string, limit: number) {
+  const pattern = `%${query}%`;
+  return {
+    projects: db
+      .prepare('SELECT id, name, description, status FROM projects WHERE name LIKE ? OR description LIKE ? LIMIT ?')
+      .all(pattern, pattern, limit),
+    epics: db
+      .prepare(
+        `SELECT e.id, e.name, e.description, e.status, e.project_id, p.name as project_name
+         FROM epics e JOIN projects p ON p.id = e.project_id
+         WHERE e.name LIKE ? OR e.description LIKE ? LIMIT ?`
+      )
+      .all(pattern, pattern, limit),
+    tasks: db
+      .prepare(
+        `SELECT t.id, t.title, t.status, t.priority, e.name as epic_name, e.project_id
+         FROM tasks t JOIN epics e ON e.id = t.epic_id
+         WHERE t.title LIKE ? OR t.description LIKE ? LIMIT ?`
+      )
+      .all(pattern, pattern, limit),
+    notes: db
+      .prepare('SELECT id, title, note_type, related_entity_type, related_entity_id, created_at FROM notes WHERE title LIKE ? OR content LIKE ? LIMIT ?')
+      .all(pattern, pattern, limit),
+  };
+}

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -1,0 +1,1192 @@
+/**
+ * The viewer is a single self-contained page: no CDN, no build step, no network
+ * calls beyond the local server. Client code avoids template literals so the
+ * whole thing can live inside this TypeScript template literal safely.
+ *
+ * Every write goes through POST /api/action, which dispatches to the same
+ * handlers the MCP tools use — so edits made here are logged and validated
+ * exactly like edits made by an agent.
+ */
+export const PAGE: string = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Saga</title>
+<style>
+:root {
+  color-scheme: light dark;
+  --bg: #f6f7f9;
+  --panel: #ffffff;
+  --panel-2: #f0f2f5;
+  --border: #dfe3e8;
+  --text: #1b1f24;
+  --muted: #6b727c;
+  --accent: #3b6cd4;
+  --todo: #8a93a0;
+  --progress: #3b6cd4;
+  --review: #8b5cf6;
+  --blocked: #d64545;
+  --done: #2e9e5b;
+  --critical: #d64545;
+  --high: #d97706;
+  --medium: #6b727c;
+  --low: #9aa2ad;
+  --radius: 10px;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #14171b;
+    --panel: #1c2025;
+    --panel-2: #23282e;
+    --border: #2e343b;
+    --text: #e6e9ed;
+    --muted: #929aa5;
+    --accent: #6a9bff;
+    --todo: #7d8794;
+    --progress: #6a9bff;
+    --review: #a78bfa;
+    --blocked: #f07171;
+    --done: #4ec27f;
+    --critical: #f07171;
+    --high: #e0a34a;
+    --medium: #929aa5;
+    --low: #6d7580;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+a { color: var(--accent); }
+header {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 10px 18px; background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  position: sticky; top: 0; z-index: 20;
+}
+.brand { font-weight: 700; font-size: 16px; letter-spacing: .5px; }
+.brand span { color: var(--accent); }
+.badge-ro {
+  font-size: 11px; padding: 2px 8px; border-radius: 999px;
+  border: 1px solid var(--blocked); color: var(--blocked);
+}
+select, input, textarea {
+  background: var(--panel-2); color: var(--text);
+  border: 1px solid var(--border); border-radius: 8px;
+  padding: 6px 10px; font: inherit; font-size: 13px;
+}
+textarea { resize: vertical; width: 100%; min-height: 90px; font-family: inherit; }
+input[type=search] { min-width: 200px; }
+input[type=checkbox] { width: auto; padding: 0; }
+.spacer { flex: 1; }
+.dbpath { font-size: 11px; color: var(--muted); font-family: ui-monospace, Menlo, Consolas, monospace; }
+button.btn {
+  background: var(--panel-2); border: 1px solid var(--border); color: var(--text);
+  border-radius: 8px; padding: 5px 11px; cursor: pointer; font: inherit; font-size: 13px;
+}
+button.btn:hover { border-color: var(--accent); color: var(--accent); }
+button.btn.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+button.btn.primary:hover { opacity: .9; color: #fff; }
+button.btn.danger:hover { border-color: var(--blocked); color: var(--blocked); }
+button.link {
+  background: none; border: none; color: var(--muted); cursor: pointer;
+  font: inherit; font-size: 12px; padding: 0 4px; text-decoration: underline;
+}
+button.link:hover { color: var(--accent); }
+nav {
+  display: flex; gap: 4px; padding: 0 18px; background: var(--panel);
+  border-bottom: 1px solid var(--border); position: sticky; top: 51px; z-index: 19;
+  overflow-x: auto;
+}
+nav button {
+  background: none; border: none; border-bottom: 2px solid transparent;
+  color: var(--muted); padding: 9px 12px; font: inherit; font-size: 13px;
+  cursor: pointer; white-space: nowrap;
+}
+nav button:hover { color: var(--text); }
+nav button.active { color: var(--text); border-bottom-color: var(--accent); font-weight: 600; }
+main { padding: 18px; max-width: 1400px; margin: 0 auto; }
+h2 { font-size: 15px; margin: 22px 0 10px; }
+h2:first-child { margin-top: 0; }
+.muted { color: var(--muted); }
+.tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
+.tile {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 12px 14px;
+}
+.tile .n { font-size: 24px; font-weight: 650; line-height: 1.1; }
+.tile .l { font-size: 11px; text-transform: uppercase; letter-spacing: .6px; color: var(--muted); margin-top: 4px; }
+.bar { height: 7px; border-radius: 999px; background: var(--panel-2); overflow: hidden; }
+.bar > i { display: block; height: 100%; background: var(--done); }
+.card {
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: var(--radius); padding: 12px 14px; margin-bottom: 10px;
+}
+.row { display: flex; align-items: center; gap: 8px; }
+.grow { flex: 1; min-width: 0; }
+.ellip { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pill {
+  font-size: 11px; padding: 1px 8px; border-radius: 999px;
+  border: 1px solid currentColor; white-space: nowrap;
+}
+.st-todo, .st-planned { color: var(--todo); }
+.st-in_progress { color: var(--progress); }
+.st-review { color: var(--review); }
+.st-blocked { color: var(--blocked); }
+.st-done, .st-completed, .st-active { color: var(--done); }
+.st-cancelled, .st-archived { color: var(--muted); }
+.st-on_hold { color: var(--high); }
+.pr-critical { color: var(--critical); }
+.pr-high { color: var(--high); }
+.pr-medium { color: var(--medium); }
+.pr-low { color: var(--low); }
+.board { display: grid; grid-template-columns: repeat(5, minmax(190px, 1fr)); gap: 10px; overflow-x: auto; }
+.col { background: var(--panel-2); border-radius: var(--radius); padding: 8px; min-height: 90px;
+       border: 1px dashed transparent; }
+.col.over { border-color: var(--accent); }
+.col h3 { margin: 2px 4px 8px; font-size: 12px; text-transform: uppercase; letter-spacing: .6px; }
+.col .count { color: var(--muted); font-weight: 400; }
+.tcard {
+  background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+  padding: 8px 10px; margin-bottom: 7px; cursor: pointer; font-size: 13px;
+}
+.tcard:hover { border-color: var(--accent); }
+.tcard.dragging { opacity: .4; }
+.tcard .meta { display: flex; gap: 6px; align-items: center; margin-top: 6px; font-size: 11px; color: var(--muted); flex-wrap: wrap; }
+.epic-head { display: flex; align-items: center; gap: 10px; }
+.epic-head .caret { cursor: pointer; }
+.epic-body { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 8px; }
+.tlist { display: flex; flex-direction: column; }
+.tline {
+  display: flex; align-items: center; gap: 9px; padding: 6px 4px;
+  border-bottom: 1px solid var(--border); cursor: pointer; font-size: 13px;
+}
+.tline:last-child { border-bottom: none; }
+.tline:hover { background: var(--panel-2); }
+.dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; flex: none; }
+pre.body {
+  white-space: pre-wrap; word-wrap: break-word; margin: 8px 0 0;
+  font: inherit; color: var(--text);
+}
+.drawer-backdrop, .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.4); z-index: 30; }
+.modal-backdrop { z-index: 40; }
+.drawer {
+  position: fixed; top: 0; right: 0; bottom: 0; width: min(640px, 100%);
+  background: var(--panel); border-left: 1px solid var(--border);
+  z-index: 31; overflow-y: auto; padding: 18px 20px 60px;
+}
+.drawer h3 {
+  margin: 18px 0 8px; font-size: 12px; text-transform: uppercase;
+  letter-spacing: .6px; color: var(--muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.modal {
+  position: fixed; z-index: 41; top: 50%; left: 50%; transform: translate(-50%, -50%);
+  width: min(560px, calc(100% - 32px)); max-height: 86vh; overflow-y: auto;
+  background: var(--panel); border: 1px solid var(--border); border-radius: 12px;
+  padding: 18px 20px;
+}
+.modal h2 { margin: 0 0 14px; font-size: 16px; }
+.field { margin-bottom: 12px; }
+.field label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
+.field input, .field select { width: 100%; }
+.field.inline { display: flex; gap: 10px; }
+.field.inline > div { flex: 1; }
+.kv { display: grid; grid-template-columns: max-content 1fr; gap: 4px 14px; font-size: 13px; }
+.kv dt { color: var(--muted); }
+.kv dd { margin: 0; }
+.cmt { border-left: 2px solid var(--border); padding: 4px 0 4px 10px; margin-bottom: 10px; }
+.cmt.deleted { opacity: .65; border-left-color: var(--blocked); }
+.cmt .hdr { font-size: 12px; color: var(--muted); display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+.strike { text-decoration: line-through; }
+.sub { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 13px; }
+.sub .grow { cursor: text; }
+.empty { color: var(--muted); font-size: 13px; padding: 6px 0; }
+.toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+.err { color: var(--blocked); }
+.act { display: flex; gap: 10px; padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 13px; }
+.act:last-child { border-bottom: none; }
+.act time { color: var(--muted); font-size: 12px; white-space: nowrap; font-variant-numeric: tabular-nums; }
+.toast {
+  position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
+  background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+  padding: 8px 14px; z-index: 60; font-size: 13px; box-shadow: 0 6px 24px rgba(0,0,0,.2);
+}
+.toast.bad { border-color: var(--blocked); color: var(--blocked); }
+</style>
+</head>
+<body>
+<header>
+  <div class="brand">saga<span>.</span></div>
+  <span class="badge-ro" id="roBadge" hidden>read-only</span>
+  <select id="projectSel" title="Project"></select>
+  <button class="btn" id="newProject" title="New project">+ Project</button>
+  <input type="search" id="q" placeholder="Search tasks, epics, notes…" autocomplete="off">
+  <div class="spacer"></div>
+  <button class="btn" id="reload" title="Reload from database">⟳</button>
+  <span class="dbpath" id="dbpath"></span>
+</header>
+<nav id="tabs"></nav>
+<main id="view"><p class="muted">Loading…</p></main>
+<script>
+var S = { projects: [], projectId: null, tab: 'overview', overview: null, tasks: [],
+          epicOpen: {}, task: null, showDeleted: false, query: '', readOnly: false };
+
+var TABS = [['overview','Overview'],['board','Board'],['epics','Epics'],['notes','Notes'],['activity','Activity']];
+var TASK_STATUS = ['todo', 'in_progress', 'review', 'blocked', 'done'];
+var EPIC_STATUS = ['planned', 'in_progress', 'completed', 'cancelled'];
+var PROJECT_STATUS = ['active', 'on_hold', 'completed', 'archived'];
+var PRIORITY = ['low', 'medium', 'high', 'critical'];
+var NOTE_TYPES = ['general','decision','context','meeting','technical','blocker','progress','release'];
+
+function esc(v) {
+  if (v === null || v === undefined) return '';
+  return String(v).replace(/[&<>"']/g, function (c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}
+function label(s) { return String(s || '').replace(/_/g, ' '); }
+function el(id) { return document.getElementById(id); }
+function fmtDate(s) {
+  if (!s) return '';
+  var raw = String(s);
+  var d = new Date(raw.replace(' ', 'T') + (raw.indexOf('Z') < 0 ? 'Z' : ''));
+  if (isNaN(d.getTime())) return esc(raw);
+  return d.toLocaleString(undefined, { year: 'numeric', month: 'short', day: 'numeric',
+                                       hour: '2-digit', minute: '2-digit' });
+}
+function get(path) {
+  return fetch(path, { headers: { 'accept': 'application/json' } }).then(function (r) {
+    return r.json().then(function (b) {
+      if (!r.ok) throw new Error(b && b.error ? b.error : r.statusText);
+      return b;
+    });
+  });
+}
+function act(tool, args) {
+  return fetch('/api/action', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-saga-ui': '1' },
+    body: JSON.stringify({ tool: tool, args: args })
+  }).then(function (r) {
+    return r.json().then(function (b) {
+      if (!r.ok || b.error) throw new Error(b && b.error ? b.error : r.statusText);
+      return b.result;
+    });
+  });
+}
+function toast(msg, bad) {
+  var t = document.createElement('div');
+  t.className = 'toast' + (bad ? ' bad' : '');
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(function () { t.remove(); }, bad ? 5000 : 2200);
+}
+function fail(e) { el('view').innerHTML = '<p class="err">' + esc(e.message || e) + '</p>'; }
+function oops(e) { toast(e.message || String(e), true); }
+
+function pill(kind, value) {
+  return '<span class="pill ' + kind + '-' + esc(value) + '">' + esc(label(value)) + '</span>';
+}
+function progressBar(pct) { return '<div class="bar"><i style="width:' + Number(pct || 0) + '%"></i></div>'; }
+function parseTags(json) { try { return JSON.parse(json || '[]'); } catch (e) { return []; } }
+function tagPills(json) {
+  return parseTags(json).map(function (t) {
+    return '<span class="pill pr-medium">' + esc(t) + '</span>';
+  }).join(' ');
+}
+function canEdit() { return !S.readOnly; }
+
+/* ---------- generic modal form ---------- */
+
+function closeModal() {
+  var m = document.querySelector('.modal');
+  var b = document.querySelector('.modal-backdrop');
+  if (m) m.remove();
+  if (b) b.remove();
+}
+
+/**
+ * fields: [{ key, label, type: text|textarea|select|number|date|tags|checkbox,
+ *            value, options, placeholder, required }]
+ * onSubmit(values, changed) -> Promise
+ */
+function modal(title, fields, submitLabel, onSubmit) {
+  closeModal();
+  var backdrop = document.createElement('div');
+  backdrop.className = 'modal-backdrop';
+  backdrop.addEventListener('click', closeModal);
+
+  var m = document.createElement('div');
+  m.className = 'modal';
+  var h = '<h2>' + esc(title) + '</h2><form id="mform">';
+  fields.forEach(function (f) {
+    var v = f.value === null || f.value === undefined ? '' : f.value;
+    h += '<div class="field"><label for="f_' + f.key + '">' + esc(f.label) + '</label>';
+    if (f.type === 'textarea') {
+      h += '<textarea id="f_' + f.key + '" name="' + f.key + '" placeholder="' +
+           esc(f.placeholder || '') + '">' + esc(v) + '</textarea>';
+    } else if (f.type === 'select') {
+      h += '<select id="f_' + f.key + '" name="' + f.key + '">';
+      (f.options || []).forEach(function (o) {
+        var val = o.value !== undefined ? o.value : o;
+        var txt = o.text !== undefined ? o.text : label(o);
+        h += '<option value="' + esc(val) + '"' + (String(val) === String(v) ? ' selected' : '') +
+             '>' + esc(txt) + '</option>';
+      });
+      h += '</select>';
+    } else if (f.type === 'tags') {
+      h += '<input id="f_' + f.key + '" name="' + f.key + '" value="' + esc(v) +
+           '" placeholder="comma, separated">';
+    } else {
+      var t = f.type === 'number' ? 'number' : f.type === 'date' ? 'date' : 'text';
+      h += '<input type="' + t + '" id="f_' + f.key + '" name="' + f.key + '" value="' + esc(v) +
+           '" placeholder="' + esc(f.placeholder || '') + '"' +
+           (t === 'number' ? ' step="any"' : '') + '>';
+    }
+    h += '</div>';
+  });
+  h += '<p class="err" id="merr" hidden></p>';
+  h += '<div class="row" style="justify-content:flex-end;margin-top:6px">' +
+       '<button type="button" class="btn" id="mcancel">Cancel</button>' +
+       '<button type="submit" class="btn primary">' + esc(submitLabel) + '</button></div></form>';
+  m.innerHTML = h;
+  document.body.appendChild(backdrop);
+  document.body.appendChild(m);
+
+  var first = m.querySelector('input, textarea, select');
+  if (first) first.focus();
+
+  m.querySelector('#mcancel').addEventListener('click', closeModal);
+  m.querySelector('#mform').addEventListener('submit', function (ev) {
+    ev.preventDefault();
+    var values = {}, changed = {};
+    var bad = null;
+    fields.forEach(function (f) {
+      var node = m.querySelector('#f_' + f.key);
+      var raw = node.value;
+      var out;
+      if (f.type === 'tags') {
+        out = raw.split(',').map(function (x) { return x.trim(); }).filter(Boolean);
+      } else if (f.type === 'number') {
+        out = raw === '' ? null : Number(raw);
+      } else {
+        out = raw.trim();
+      }
+      if (f.required && (out === '' || out === null)) bad = f.label + ' is required.';
+      values[f.key] = out;
+      var before = f.type === 'tags' ? (f.value || '') : (f.value === null || f.value === undefined ? '' : f.value);
+      var after = f.type === 'tags' ? out.join(', ') : (out === null ? '' : String(out));
+      if (String(before) !== after) changed[f.key] = out;
+    });
+    var errNode = m.querySelector('#merr');
+    if (bad) { errNode.hidden = false; errNode.textContent = bad; return; }
+    errNode.hidden = true;
+    var btn = m.querySelector('button[type=submit]');
+    btn.disabled = true;
+    Promise.resolve(onSubmit(values, changed)).then(function () {
+      closeModal();
+    }).catch(function (e) {
+      btn.disabled = false;
+      errNode.hidden = false;
+      errNode.textContent = e.message || String(e);
+    });
+  });
+}
+
+/* ---------- shell ---------- */
+
+function renderTabs() {
+  el('tabs').innerHTML = TABS.map(function (t) {
+    return '<button data-tab="' + t[0] + '" class="' + (S.tab === t[0] ? 'active' : '') + '">' + t[1] + '</button>';
+  }).join('');
+}
+
+function renderProjects() {
+  var sel = el('projectSel');
+  if (!S.projects.length) { sel.innerHTML = '<option value="">No projects</option>'; return; }
+  sel.innerHTML = S.projects.map(function (p) {
+    return '<option value="' + p.id + '"' + (p.id === S.projectId ? ' selected' : '') + '>' +
+           esc(p.name) + ' · ' + (p.task_count || 0) + ' tasks</option>';
+  }).join('');
+}
+
+function reloadProjects() {
+  return get('/api/projects').then(function (r) {
+    S.projects = r.projects;
+    renderProjects();
+  });
+}
+
+function loadProject(keepDrawer) {
+  if (!S.projectId) {
+    el('view').innerHTML = '<p class="empty">No projects in this database yet. ' +
+      (canEdit() ? 'Use <b>+ Project</b> above to create one.'
+                 : 'Create one with the <code>tracker_init</code> MCP tool.') + '</p>';
+    return Promise.resolve();
+  }
+  return Promise.all([
+    get('/api/overview?project_id=' + S.projectId),
+    get('/api/tasks?project_id=' + S.projectId)
+  ]).then(function (r) {
+    S.overview = r[0];
+    S.tasks = r[1].tasks;
+    render();
+    if (keepDrawer && S.task) return openTask(S.task.id);
+  }).catch(fail);
+}
+
+/** Refresh everything after a write, keeping the open task drawer in sync. */
+function refresh() {
+  return reloadProjects().then(function () { return loadProject(true); });
+}
+
+function render() {
+  renderTabs();
+  el('roBadge').hidden = !S.readOnly;
+  if (S.query) return renderSearch();
+  var fns = { overview: viewOverview, board: viewBoard, epics: viewEpics,
+              notes: viewNotes, activity: viewActivity };
+  (fns[S.tab] || viewOverview)();
+}
+
+/* ---------- overview ---------- */
+
+function viewOverview() {
+  var o = S.overview;
+  if (!o) return;
+  var s = o.stats || {};
+  var h = '<div class="tiles">' +
+    tile(s.total_tasks || 0, 'tasks') + tile(s.tasks_done || 0, 'done') +
+    tile(s.tasks_in_progress || 0, 'in progress') + tile(s.tasks_review || 0, 'in review') +
+    tile(s.tasks_blocked || 0, 'blocked') + tile(o.overdue_tasks.length, 'overdue') +
+    '</div>';
+
+  h += '<div class="card" style="margin-top:12px">' +
+    '<div class="row"><strong class="grow">' + esc(o.project.name) + '</strong>' +
+    pill('st', o.project.status) +
+    '<span class="muted">' + (s.completion_pct || 0) + '% complete</span>' +
+    (canEdit() ? '<button class="btn" id="editProject">Edit</button>' : '') + '</div>' +
+    (o.project.description ? '<pre class="body muted">' + esc(o.project.description) + '</pre>' : '') +
+    '<div style="margin-top:10px">' + progressBar(s.completion_pct) + '</div>' +
+    '</div>';
+
+  h += '<h2>Epics <span class="muted">(' + o.epics.length + ')</span>' +
+       (canEdit() ? ' <button class="btn" id="newEpic">+ Epic</button>' : '') + '</h2>';
+  if (!o.epics.length) h += '<p class="empty">No epics yet.</p>';
+  o.epics.forEach(function (e) {
+    h += '<div class="card" data-epic-open="' + e.id + '" style="cursor:pointer">' +
+      '<div class="row"><span class="grow ellip"><strong>' + esc(e.name) + '</strong></span>' +
+      (e.branch ? '<span class="pill pr-low" title="branch">⎇ ' + esc(e.branch) + '</span> ' : '') +
+      pill('pr', e.priority) + ' ' + pill('st', e.status) + '</div>' +
+      '<div class="row" style="margin-top:8px"><span class="grow">' + progressBar(e.completion_pct) + '</span>' +
+      '<span class="muted" style="font-size:12px">' + (e.done_count || 0) + '/' + (e.task_count || 0) +
+      (e.blocked_count ? ' · ' + e.blocked_count + ' blocked' : '') + '</span></div></div>';
+  });
+
+  if (o.blocked_tasks.length) h += '<h2>Blocked</h2>' + o.blocked_tasks.map(function (t) { return taskLine(t); }).join('');
+  if (o.overdue_tasks.length) {
+    h += '<h2>Overdue</h2>' + o.overdue_tasks.map(function (t) {
+      return taskLine(t, 'due ' + esc(t.due_date));
+    }).join('');
+  }
+  el('view').innerHTML = h;
+}
+
+function tile(n, l) {
+  return '<div class="tile"><div class="n">' + n + '</div><div class="l">' + l + '</div></div>';
+}
+
+function taskLine(t, extra) {
+  return '<div class="tline" data-task="' + t.id + '">' +
+    '<span class="dot st-' + esc(t.status) + '"></span>' +
+    '<span class="grow ellip">' + esc(t.title) + '</span>' +
+    (extra ? '<span class="muted" style="font-size:12px">' + extra + '</span>' : '') +
+    (t.epic_name ? '<span class="muted ellip" style="font-size:12px;max-width:180px">' + esc(t.epic_name) + '</span>' : '') +
+    pill('pr', t.priority) + '</div>';
+}
+
+/* ---------- board ---------- */
+
+function viewBoard() {
+  var byStatus = {};
+  TASK_STATUS.forEach(function (s) { byStatus[s] = []; });
+  S.tasks.forEach(function (t) { (byStatus[t.status] || (byStatus[t.status] = [])).push(t); });
+
+  var h = '';
+  if (canEdit()) h += '<div class="toolbar"><span class="muted">Drag a card to change its status.</span></div>';
+  h += '<div class="board">';
+  TASK_STATUS.forEach(function (st) {
+    var list = byStatus[st] || [];
+    h += '<div class="col" data-status="' + st + '"><h3 class="st-' + st + '">' + esc(label(st)) +
+         ' <span class="count">' + list.length + '</span></h3>';
+    list.forEach(function (t) { h += taskCard(t); });
+    if (!list.length) h += '<div class="empty" style="padding:4px">—</div>';
+    h += '</div>';
+  });
+  h += '</div>';
+  el('view').innerHTML = h;
+}
+
+function taskCard(t) {
+  var meta = [];
+  if (t.subtask_count) meta.push('☑ ' + t.subtask_done + '/' + t.subtask_count);
+  if (t.comment_count) meta.push('💬 ' + t.comment_count);
+  if (t.due_date) meta.push('📅 ' + esc(t.due_date));
+  if (t.assigned_to) meta.push('@' + esc(t.assigned_to));
+  return '<div class="tcard" data-task="' + t.id + '"' + (canEdit() ? ' draggable="true"' : '') + '>' +
+    esc(t.title) +
+    '<div class="meta">' + pill('pr', t.priority) + '<span class="ellip grow">' + esc(t.epic_name) + '</span></div>' +
+    (meta.length ? '<div class="meta">' + meta.join(' · ') + '</div>' : '') + '</div>';
+}
+
+/* ---------- epics ---------- */
+
+function viewEpics() {
+  var o = S.overview;
+  if (!o) return;
+  var byEpic = {};
+  S.tasks.forEach(function (t) { (byEpic[t.epic_id] || (byEpic[t.epic_id] = [])).push(t); });
+
+  var h = '<div class="toolbar">' +
+    (canEdit() ? '<button class="btn primary" id="newEpic">+ Epic</button>' : '') +
+    '<button class="btn" id="expandAll">Expand all</button>' +
+    '<button class="btn" id="collapseAll">Collapse all</button></div>';
+  if (!o.epics.length) h += '<p class="empty">No epics yet.</p>';
+
+  o.epics.forEach(function (e) {
+    var open = S.epicOpen[e.id];
+    var list = byEpic[e.id] || [];
+    h += '<div class="card"><div class="epic-head">' +
+      '<span class="caret grow row" data-toggle="' + e.id + '" style="cursor:pointer">' +
+        '<span class="muted">' + (open ? '▾' : '▸') + '</span>' +
+        '<span class="grow ellip"><strong>' + esc(e.name) + '</strong></span></span>' +
+      (e.branch ? '<span class="pill pr-low">⎇ ' + esc(e.branch) + '</span>' : '') +
+      pill('pr', e.priority) + pill('st', e.status) +
+      '<span class="muted" style="font-size:12px">' + (e.done_count || 0) + '/' + (e.task_count || 0) + '</span>' +
+      (canEdit() ? '<button class="btn" data-edit-epic="' + e.id + '">Edit</button>' +
+                   '<button class="btn" data-new-task="' + e.id + '">+ Task</button>' : '') +
+      '</div>';
+    if (open) {
+      h += '<div class="epic-body">' +
+        (e.description ? '<pre class="body muted" style="margin-bottom:10px">' + esc(e.description) + '</pre>' : '') +
+        '<div class="tlist">' +
+        (list.length ? list.map(function (t) {
+          var extra = t.subtask_count ? '☑ ' + t.subtask_done + '/' + t.subtask_count : '';
+          var copy = {};
+          for (var k in t) copy[k] = t[k];
+          copy.epic_name = '';
+          return taskLine(copy, extra);
+        }).join('') : '<div class="empty">No tasks in this epic.</div>') +
+        '</div></div>';
+    }
+    h += '</div>';
+  });
+  el('view').innerHTML = h;
+}
+
+/* ---------- notes ---------- */
+
+function viewNotes() {
+  el('view').innerHTML = '<p class="muted">Loading…</p>';
+  get('/api/notes?project_id=' + S.projectId + '&limit=200').then(function (r) {
+    var h = canEdit() ? '<div class="toolbar"><button class="btn primary" id="newNote">+ Note</button></div>' : '';
+    if (!r.notes.length) {
+      el('view').innerHTML = h + '<p class="empty">No notes yet.</p>';
+      return;
+    }
+    h += r.notes.map(function (n) {
+      return '<div class="card">' +
+        '<div class="row"><strong class="grow">' + esc(n.title) + '</strong>' +
+        '<span class="pill pr-medium">' + esc(label(n.note_type)) + '</span>' +
+        '<span class="muted" style="font-size:12px">' + fmtDate(n.created_at) + '</span>' +
+        (canEdit() ? '<button class="btn" data-edit-note="' + n.id + '">Edit</button>' +
+                     '<button class="btn danger" data-del-note="' + n.id + '">Delete</button>' : '') +
+        '</div>' +
+        (n.related_entity_type ? '<div class="muted" style="font-size:12px;margin-top:2px">on ' +
+          esc(n.related_entity_type) + ' #' + esc(n.related_entity_id) + '</div>' : '') +
+        '<pre class="body">' + esc(n.content) + '</pre>' +
+        (tagPills(n.tags) ? '<div style="margin-top:8px">' + tagPills(n.tags) + '</div>' : '') +
+        '</div>';
+    }).join('');
+    el('view').innerHTML = h;
+    S.notes = r.notes;
+  }).catch(fail);
+}
+
+/* ---------- activity ---------- */
+
+function viewActivity() {
+  el('view').innerHTML = '<p class="muted">Loading…</p>';
+  get('/api/activity?project_id=' + S.projectId + '&limit=250').then(function (r) {
+    if (!r.activity.length) { el('view').innerHTML = '<p class="empty">No activity recorded yet.</p>'; return; }
+    el('view').innerHTML = '<div class="card">' + r.activity.map(function (a) {
+      var clickable = a.entity_type === 'task';
+      return '<div class="act"' + (clickable ? ' data-task="' + a.entity_id + '" style="cursor:pointer"' : '') + '>' +
+        '<time>' + fmtDate(a.created_at) + '</time>' +
+        '<span class="pill pr-medium">' + esc(label(a.action)) + '</span>' +
+        '<span class="grow">' + esc(a.summary || (a.entity_type + ' #' + a.entity_id)) + '</span></div>';
+    }).join('') + '</div>';
+  }).catch(fail);
+}
+
+/* ---------- search ---------- */
+
+function renderSearch() {
+  el('view').innerHTML = '<p class="muted">Searching…</p>';
+  get('/api/search?q=' + encodeURIComponent(S.query)).then(function (r) {
+    var h = '<div class="toolbar"><strong>Results for “' + esc(S.query) + '”</strong>' +
+            '<button class="btn" id="clearSearch">Clear</button></div>';
+    var total = 0;
+    if (r.tasks.length) {
+      total += r.tasks.length;
+      h += '<h2>Tasks</h2>' + r.tasks.map(function (t) { return taskLine(t); }).join('');
+    }
+    if (r.epics.length) {
+      total += r.epics.length;
+      h += '<h2>Epics</h2>' + r.epics.map(function (e) {
+        return '<div class="tline" data-goto-epic="' + e.id + '" data-project="' + e.project_id + '">' +
+          '<span class="dot st-' + esc(e.status) + '"></span><span class="grow ellip">' + esc(e.name) + '</span>' +
+          '<span class="muted" style="font-size:12px">' + esc(e.project_name) + '</span></div>';
+      }).join('');
+    }
+    if (r.notes.length) {
+      total += r.notes.length;
+      h += '<h2>Notes</h2>' + r.notes.map(function (n) {
+        return '<div class="tline"><span class="dot" style="color:var(--muted)"></span>' +
+          '<span class="grow ellip">' + esc(n.title) + '</span>' +
+          '<span class="pill pr-medium">' + esc(label(n.note_type)) + '</span></div>';
+      }).join('');
+    }
+    if (r.projects.length) {
+      total += r.projects.length;
+      h += '<h2>Projects</h2>' + r.projects.map(function (p) {
+        return '<div class="tline" data-project="' + p.id + '"><span class="dot st-' + esc(p.status) +
+          '"></span><span class="grow ellip">' + esc(p.name) + '</span></div>';
+      }).join('');
+    }
+    if (!total) h += '<p class="empty">Nothing matched.</p>';
+    el('view').innerHTML = h;
+  }).catch(fail);
+}
+
+/* ---------- task drawer ---------- */
+
+function openTask(id) {
+  return get('/api/tasks/' + id + (S.showDeleted ? '?include_deleted=1' : '')).then(function (t) {
+    S.task = t;
+    drawTask();
+  }).catch(oops);
+}
+
+function closeDrawer() {
+  S.task = null;
+  var d = document.querySelector('.drawer');
+  var b = document.querySelector('.drawer-backdrop');
+  if (d) d.remove();
+  if (b) b.remove();
+}
+
+function drawTask() {
+  var scroll = 0;
+  var existing = document.querySelector('.drawer');
+  if (existing) { scroll = existing.scrollTop; existing.remove(); }
+  var oldBackdrop = document.querySelector('.drawer-backdrop');
+  if (oldBackdrop) oldBackdrop.remove();
+
+  var t = S.task;
+  if (!t) return;
+  var ed = canEdit();
+
+  var backdrop = document.createElement('div');
+  backdrop.className = 'drawer-backdrop';
+  backdrop.addEventListener('click', closeDrawer);
+
+  var d = document.createElement('div');
+  d.className = 'drawer';
+
+  var h = '<div class="row"><span class="grow"></span>' +
+    (ed ? '<button class="btn" id="editTask">Edit task</button>' : '') +
+    '<button class="btn" id="closeDrawer">Close ✕</button></div>';
+  h += '<h2 style="margin:6px 0 8px;font-size:18px">' + esc(t.title) + '</h2>';
+  h += '<div class="row" style="gap:6px;flex-wrap:wrap">';
+  if (ed) {
+    h += '<select id="quickStatus" title="Status">' + TASK_STATUS.map(function (s) {
+      return '<option value="' + s + '"' + (s === t.status ? ' selected' : '') + '>' + esc(label(s)) + '</option>';
+    }).join('') + '</select>';
+    h += '<select id="quickPriority" title="Priority">' + PRIORITY.map(function (p) {
+      return '<option value="' + p + '"' + (p === t.priority ? ' selected' : '') + '>' + esc(p) + '</option>';
+    }).join('') + '</select>';
+  } else {
+    h += pill('st', t.status) + pill('pr', t.priority);
+  }
+  h += '<span class="muted" style="font-size:12px">#' + t.id + ' · ' + esc(t.project_name) +
+       ' › ' + esc(t.epic_name) + '</span></div>';
+
+  var kv = [];
+  if (t.assigned_to) kv.push(['Assigned', esc(t.assigned_to)]);
+  if (t.due_date) kv.push(['Due', esc(t.due_date)]);
+  if (t.estimated_hours !== null && t.estimated_hours !== undefined) kv.push(['Estimated', t.estimated_hours + 'h']);
+  if (t.actual_hours !== null && t.actual_hours !== undefined) kv.push(['Actual', t.actual_hours + 'h']);
+  if (t.epic_branch) kv.push(['Branch', esc(t.epic_branch)]);
+  if (t.source_ref) kv.push(['Source', esc(t.source_ref)]);
+  kv.push(['Created', fmtDate(t.created_at)]);
+  kv.push(['Updated', fmtDate(t.updated_at)]);
+  h += '<dl class="kv" style="margin-top:12px">' + kv.map(function (r) {
+    return '<dt>' + r[0] + '</dt><dd>' + r[1] + '</dd>';
+  }).join('') + '</dl>';
+  if (tagPills(t.tags)) h += '<div style="margin-top:10px">' + tagPills(t.tags) + '</div>';
+
+  h += '<h3>Description</h3>' +
+    (t.description ? '<pre class="body">' + esc(t.description) + '</pre>'
+                   : '<div class="empty">No description.</div>');
+
+  h += '<h3>Subtasks <span class="muted">(' + t.subtasks.length + ')</span></h3>';
+  h += t.subtasks.length ? t.subtasks.map(function (s) {
+    return '<div class="sub">' +
+      (ed ? '<input type="checkbox" data-subtask-toggle="' + s.id + '"' +
+            (s.status === 'done' ? ' checked' : '') + '>'
+          : '<span class="dot st-' + esc(s.status) + '"></span>') +
+      '<span class="grow' + (s.status === 'done' ? ' muted strike' : '') + '">' + esc(s.title) + '</span>' +
+      (ed ? '<button class="link" data-subtask-rename="' + s.id + '">rename</button>' +
+            '<button class="link" data-subtask-del="' + s.id + '">remove</button>' : '') +
+      '</div>';
+  }).join('') : '<div class="empty">None.</div>';
+  if (ed) {
+    h += '<div class="row" style="margin-top:8px">' +
+      '<input id="newSubtask" class="grow" placeholder="Add a subtask and press Enter">' +
+      '<button class="btn" id="addSubtask">Add</button></div>';
+  }
+
+  if (t.depends_on.length || t.dependents.length) {
+    h += '<h3>Dependencies</h3>';
+    t.depends_on.forEach(function (x) {
+      h += '<div class="sub"><span class="muted">blocked by</span><span class="dot st-' + esc(x.status) +
+           '"></span><a href="#" data-task="' + x.id + '">' + esc(x.title) + '</a></div>';
+    });
+    t.dependents.forEach(function (x) {
+      h += '<div class="sub"><span class="muted">blocks</span><span class="dot st-' + esc(x.status) +
+           '"></span><a href="#" data-task="' + x.id + '">' + esc(x.title) + '</a></div>';
+    });
+  }
+
+  var liveComments = t.comments.filter(function (c) { return !c.is_deleted; }).length;
+  h += '<h3>Comments <span class="muted">(' + liveComments + ')</span></h3>';
+  if (t.deleted_comment_count) {
+    h += '<label class="muted" style="font-size:12px;display:block;margin-bottom:8px">' +
+      '<input type="checkbox" id="showDeleted"' + (S.showDeleted ? ' checked' : '') + '> ' +
+      'show ' + t.deleted_comment_count + ' removed comment' + (t.deleted_comment_count === 1 ? '' : 's') + '</label>';
+  }
+  h += t.comments.length ? t.comments.map(function (c) {
+    var head = (c.author ? esc(c.author) : 'anonymous') + ' · ' + fmtDate(c.created_at);
+    if (c.is_deleted) head += ' · removed ' + fmtDate(c.deleted_at) + (c.deleted_by ? ' by ' + esc(c.deleted_by) : '');
+    return '<div class="cmt' + (c.is_deleted ? ' deleted' : '') + '">' +
+      '<div class="hdr"><span class="grow">' + head + '</span>' +
+      (ed ? (c.is_deleted ? '<button class="link" data-cmt-restore="' + c.id + '">restore</button>'
+                          : '<button class="link" data-cmt-del="' + c.id + '">remove</button>') : '') +
+      '</div>' +
+      '<pre class="body' + (c.is_deleted ? ' strike' : '') + '">' + esc(c.content) + '</pre>' +
+      (c.is_deleted && c.delete_reason ? '<div class="hdr">reason: ' + esc(c.delete_reason) + '</div>' : '') +
+      '</div>';
+  }).join('') : '<div class="empty">No comments.</div>';
+  if (ed) {
+    h += '<div style="margin-top:8px"><textarea id="newComment" placeholder="Add a comment…" ' +
+      'style="min-height:70px"></textarea>' +
+      '<div class="row" style="margin-top:6px"><input id="commentAuthor" placeholder="your name (optional)" ' +
+      'style="max-width:220px"><span class="grow"></span>' +
+      '<button class="btn primary" id="addComment">Comment</button></div></div>';
+  }
+
+  h += '<h3>Notes' + (ed ? ' <button class="btn" id="addTaskNote">+ Note</button>' : '') + '</h3>';
+  h += t.notes.length ? t.notes.map(function (n) {
+    return '<div class="cmt"><div class="hdr">' + esc(label(n.note_type)) + ' · ' + fmtDate(n.created_at) +
+      '</div><strong>' + esc(n.title) + '</strong><pre class="body">' + esc(n.content) + '</pre></div>';
+  }).join('') : '<div class="empty">None.</div>';
+
+  if (t.activity.length) {
+    h += '<h3>History</h3>' + t.activity.map(function (a) {
+      return '<div class="act"><time>' + fmtDate(a.created_at) + '</time>' +
+        '<span class="grow">' + esc(a.summary || a.action) + '</span></div>';
+    }).join('');
+  }
+
+  d.innerHTML = h;
+  document.body.appendChild(backdrop);
+  document.body.appendChild(d);
+  d.scrollTop = scroll;
+}
+
+/* ---------- write actions ---------- */
+
+function editTaskModal() {
+  var t = S.task;
+  modal('Edit task #' + t.id, [
+    { key: 'title', label: 'Title', type: 'text', value: t.title, required: true },
+    { key: 'description', label: 'Description', type: 'textarea', value: t.description },
+    { key: 'status', label: 'Status', type: 'select', options: TASK_STATUS, value: t.status },
+    { key: 'priority', label: 'Priority', type: 'select', options: PRIORITY, value: t.priority },
+    { key: 'assigned_to', label: 'Assigned to', type: 'text', value: t.assigned_to },
+    { key: 'due_date', label: 'Due date', type: 'date', value: t.due_date },
+    { key: 'estimated_hours', label: 'Estimated hours', type: 'number', value: t.estimated_hours },
+    { key: 'actual_hours', label: 'Actual hours', type: 'number', value: t.actual_hours },
+    { key: 'tags', label: 'Tags', type: 'tags', value: parseTags(t.tags).join(', ') }
+  ], 'Save', function (values, changed) {
+    if (!Object.keys(changed).length) return Promise.resolve();
+    changed.id = t.id;
+    return act('task_update', changed).then(function () {
+      toast('Task updated');
+      return refresh();
+    });
+  });
+}
+
+function newTaskModal(epicId) {
+  modal('New task', [
+    { key: 'title', label: 'Title', type: 'text', value: '', required: true },
+    { key: 'description', label: 'Description', type: 'textarea', value: '' },
+    { key: 'status', label: 'Status', type: 'select', options: TASK_STATUS, value: 'todo' },
+    { key: 'priority', label: 'Priority', type: 'select', options: PRIORITY, value: 'medium' },
+    { key: 'assigned_to', label: 'Assigned to', type: 'text', value: '' },
+    { key: 'due_date', label: 'Due date', type: 'date', value: '' },
+    { key: 'estimated_hours', label: 'Estimated hours', type: 'number', value: '' },
+    { key: 'tags', label: 'Tags', type: 'tags', value: '' }
+  ], 'Create', function (values) {
+    var args = { epic_id: epicId, title: values.title, status: values.status, priority: values.priority };
+    if (values.description) args.description = values.description;
+    if (values.assigned_to) args.assigned_to = values.assigned_to;
+    if (values.due_date) args.due_date = values.due_date;
+    if (values.estimated_hours !== null) args.estimated_hours = values.estimated_hours;
+    if (values.tags.length) args.tags = values.tags;
+    return act('task_create', args).then(function () {
+      toast('Task created');
+      S.epicOpen[epicId] = true;
+      return refresh();
+    });
+  });
+}
+
+function epicModal(epic) {
+  var isNew = !epic;
+  modal(isNew ? 'New epic' : 'Edit epic', [
+    { key: 'name', label: 'Name', type: 'text', value: isNew ? '' : epic.name, required: true },
+    { key: 'description', label: 'Description', type: 'textarea', value: isNew ? '' : epic.description },
+    { key: 'status', label: 'Status', type: 'select', options: EPIC_STATUS, value: isNew ? 'planned' : epic.status },
+    { key: 'priority', label: 'Priority', type: 'select', options: PRIORITY, value: isNew ? 'medium' : epic.priority },
+    { key: 'branch', label: 'Git branch (blank = all branches)', type: 'text', value: isNew ? '' : epic.branch },
+    { key: 'tags', label: 'Tags', type: 'tags', value: isNew ? '' : parseTags(epic.tags).join(', ') }
+  ], isNew ? 'Create' : 'Save', function (values, changed) {
+    if (isNew) {
+      var args = { project_id: S.projectId, name: values.name, status: values.status, priority: values.priority };
+      if (values.description) args.description = values.description;
+      if (values.branch) args.branch = values.branch;
+      if (values.tags.length) args.tags = values.tags;
+      return act('epic_create', args).then(function () { toast('Epic created'); return refresh(); });
+    }
+    if (!Object.keys(changed).length) return Promise.resolve();
+    changed.id = epic.id;
+    return act('epic_update', changed).then(function () { toast('Epic updated'); return refresh(); });
+  });
+}
+
+function projectModal(project) {
+  var isNew = !project;
+  modal(isNew ? 'New project' : 'Edit project', [
+    { key: 'name', label: 'Name', type: 'text', value: isNew ? '' : project.name, required: true },
+    { key: 'description', label: 'Description', type: 'textarea', value: isNew ? '' : project.description },
+    { key: 'status', label: 'Status', type: 'select', options: PROJECT_STATUS, value: isNew ? 'active' : project.status },
+    { key: 'tags', label: 'Tags', type: 'tags', value: isNew ? '' : parseTags(project.tags).join(', ') }
+  ], isNew ? 'Create' : 'Save', function (values, changed) {
+    if (isNew) {
+      var args = { name: values.name, status: values.status };
+      if (values.description) args.description = values.description;
+      if (values.tags.length) args.tags = values.tags;
+      return act('project_create', args).then(function (p) {
+        toast('Project created');
+        S.projectId = p.id;
+        S.epicOpen = {};
+        S.tab = 'overview';
+        return refresh();
+      });
+    }
+    if (!Object.keys(changed).length) return Promise.resolve();
+    changed.id = project.id;
+    return act('project_update', changed).then(function () { toast('Project updated'); return refresh(); });
+  });
+}
+
+function noteModal(note, related) {
+  var isNew = !note;
+  var fields = [
+    { key: 'title', label: 'Title', type: 'text', value: isNew ? '' : note.title, required: true },
+    { key: 'content', label: 'Content', type: 'textarea', value: isNew ? '' : note.content, required: true },
+    { key: 'note_type', label: 'Type', type: 'select', options: NOTE_TYPES,
+      value: isNew ? 'general' : note.note_type },
+    { key: 'tags', label: 'Tags', type: 'tags', value: isNew ? '' : parseTags(note.tags).join(', ') }
+  ];
+  modal(isNew ? 'New note' : 'Edit note', fields, isNew ? 'Save note' : 'Save', function (values, changed) {
+    var args = { title: values.title, content: values.content, note_type: values.note_type, tags: values.tags };
+    if (!isNew) args.id = note.id;
+    if (isNew) {
+      var link = related || { type: 'project', id: S.projectId };
+      args.related_entity_type = link.type;
+      args.related_entity_id = link.id;
+    }
+    return act('note_save', args).then(function () {
+      toast(isNew ? 'Note saved' : 'Note updated');
+      return refresh();
+    });
+  });
+}
+
+/* ---------- events ---------- */
+
+document.addEventListener('click', function (ev) {
+  var target = ev.target;
+
+  var tabBtn = target.closest('nav button');
+  if (tabBtn) { S.tab = tabBtn.dataset.tab; S.query = ''; el('q').value = ''; render(); return; }
+
+  if (target.id === 'closeDrawer') return closeDrawer();
+  if (target.id === 'clearSearch') { S.query = ''; el('q').value = ''; render(); return; }
+  if (target.id === 'reload') { toast('Reloaded'); refresh(); return; }
+  if (target.id === 'expandAll') { S.overview.epics.forEach(function (e) { S.epicOpen[e.id] = true; }); render(); return; }
+  if (target.id === 'collapseAll') { S.epicOpen = {}; render(); return; }
+  if (target.id === 'newProject') return projectModal(null);
+  if (target.id === 'editProject') return projectModal(S.overview.project);
+  if (target.id === 'newEpic') return epicModal(null);
+  if (target.id === 'newNote') return noteModal(null, null);
+  if (target.id === 'editTask') return editTaskModal();
+  if (target.id === 'addTaskNote') return noteModal(null, { type: 'task', id: S.task.id });
+
+  if (target.id === 'addSubtask') return submitSubtask();
+  if (target.id === 'addComment') return submitComment();
+
+  var editEpic = target.closest('[data-edit-epic]');
+  if (editEpic) {
+    var eid = Number(editEpic.dataset.editEpic);
+    var epic = S.overview.epics.filter(function (x) { return x.id === eid; })[0];
+    return epicModal(epic);
+  }
+
+  var newTask = target.closest('[data-new-task]');
+  if (newTask) return newTaskModal(Number(newTask.dataset.newTask));
+
+  var editNote = target.closest('[data-edit-note]');
+  if (editNote) {
+    var nid = Number(editNote.dataset.editNote);
+    var note = (S.notes || []).filter(function (x) { return x.id === nid; })[0];
+    return noteModal(note, null);
+  }
+
+  var delNote = target.closest('[data-del-note]');
+  if (delNote) {
+    if (!confirm('Delete this note? Notes are deleted permanently.')) return;
+    return act('note_delete', { id: Number(delNote.dataset.delNote) })
+      .then(function () { toast('Note deleted'); viewNotes(); }).catch(oops);
+  }
+
+  var renameSub = target.closest('[data-subtask-rename]');
+  if (renameSub) {
+    var sid = Number(renameSub.dataset.subtaskRename);
+    var sub = S.task.subtasks.filter(function (x) { return x.id === sid; })[0];
+    var title = prompt('Subtask title', sub.title);
+    if (title === null || !title.trim() || title === sub.title) return;
+    return act('subtask_update', { id: sid, title: title.trim() })
+      .then(function () { return refresh(); }).catch(oops);
+  }
+
+  var delSub = target.closest('[data-subtask-del]');
+  if (delSub) {
+    if (!confirm('Remove this subtask?')) return;
+    return act('subtask_delete', { ids: Number(delSub.dataset.subtaskDel) })
+      .then(function () { return refresh(); }).catch(oops);
+  }
+
+  var delCmt = target.closest('[data-cmt-del]');
+  if (delCmt) {
+    var reason = prompt('Why is this comment being removed? (kept in the audit trail)');
+    if (reason === null) return;
+    return act('comment_delete', { id: Number(delCmt.dataset.cmtDel), reason: reason || null })
+      .then(function () { toast('Comment removed'); return refresh(); }).catch(oops);
+  }
+
+  var restoreCmt = target.closest('[data-cmt-restore]');
+  if (restoreCmt) {
+    return act('comment_restore', { id: Number(restoreCmt.dataset.cmtRestore) })
+      .then(function () { toast('Comment restored'); return refresh(); }).catch(oops);
+  }
+
+  var taskNode = target.closest('[data-task]');
+  if (taskNode) { ev.preventDefault(); openTask(Number(taskNode.dataset.task)); return; }
+
+  var toggle = target.closest('[data-toggle]');
+  if (toggle) {
+    var tid = toggle.dataset.toggle;
+    S.epicOpen[tid] = !S.epicOpen[tid];
+    render();
+    return;
+  }
+
+  var openEpic = target.closest('[data-epic-open]');
+  if (openEpic) {
+    S.epicOpen = {};
+    S.epicOpen[openEpic.dataset.epicOpen] = true;
+    S.tab = 'epics';
+    render();
+    return;
+  }
+
+  var gotoEpic = target.closest('[data-goto-epic]');
+  if (gotoEpic) {
+    var pid = Number(gotoEpic.dataset.project);
+    S.epicOpen = {};
+    S.epicOpen[gotoEpic.dataset.gotoEpic] = true;
+    S.tab = 'epics';
+    S.query = '';
+    el('q').value = '';
+    if (pid !== S.projectId) {
+      S.projectId = pid;
+      el('projectSel').value = String(pid);
+      loadProject();
+    } else render();
+    return;
+  }
+
+  var projNode = target.closest('[data-project]');
+  if (projNode) {
+    S.projectId = Number(projNode.dataset.project);
+    el('projectSel').value = String(S.projectId);
+    S.query = ''; el('q').value = ''; S.tab = 'overview';
+    loadProject();
+    return;
+  }
+});
+
+function submitSubtask() {
+  var input = el('newSubtask');
+  var title = input.value.trim();
+  if (!title) return;
+  input.value = '';
+  act('subtask_create', { task_id: S.task.id, titles: title })
+    .then(function () { return refresh(); }).catch(oops);
+}
+
+function submitComment() {
+  var box = el('newComment');
+  var content = box.value.trim();
+  if (!content) return;
+  var author = el('commentAuthor').value.trim();
+  var args = { task_id: S.task.id, content: content };
+  if (author) args.author = author;
+  box.value = '';
+  act('comment_add', args).then(function () { toast('Comment added'); return refresh(); }).catch(oops);
+}
+
+document.addEventListener('change', function (ev) {
+  var target = ev.target;
+  if (target.id === 'projectSel') {
+    S.projectId = Number(target.value);
+    S.epicOpen = {};
+    loadProject();
+    return;
+  }
+  if (target.id === 'showDeleted') {
+    S.showDeleted = target.checked;
+    openTask(S.task.id);
+    return;
+  }
+  if (target.id === 'quickStatus') {
+    act('task_update', { id: S.task.id, status: target.value })
+      .then(function () { toast('Status updated'); return refresh(); }).catch(oops);
+    return;
+  }
+  if (target.id === 'quickPriority') {
+    act('task_update', { id: S.task.id, priority: target.value })
+      .then(function () { toast('Priority updated'); return refresh(); }).catch(oops);
+    return;
+  }
+  var subToggle = target.closest('[data-subtask-toggle]');
+  if (subToggle) {
+    act('subtask_update', { id: Number(subToggle.dataset.subtaskToggle),
+                            status: target.checked ? 'done' : 'todo' })
+      .then(function () { return refresh(); }).catch(oops);
+  }
+});
+
+document.addEventListener('keydown', function (ev) {
+  if (ev.key === 'Escape') {
+    if (document.querySelector('.modal')) closeModal();
+    else if (document.querySelector('.drawer')) closeDrawer();
+    else if (S.query) { S.query = ''; el('q').value = ''; render(); }
+    return;
+  }
+  if (ev.key === 'Enter' && ev.target.id === 'newSubtask') { ev.preventDefault(); submitSubtask(); }
+  if (ev.key === 'Enter' && (ev.metaKey || ev.ctrlKey) && ev.target.id === 'newComment') submitComment();
+});
+
+var qTimer = null;
+document.addEventListener('input', function (ev) {
+  if (ev.target.id !== 'q') return;
+  clearTimeout(qTimer);
+  var v = ev.target.value.trim();
+  qTimer = setTimeout(function () { S.query = v.length >= 2 ? v : ''; render(); }, 220);
+});
+
+/* drag a board card into another status column */
+var dragId = null;
+document.addEventListener('dragstart', function (ev) {
+  var card = ev.target.closest ? ev.target.closest('.tcard[draggable]') : null;
+  if (!card) return;
+  dragId = Number(card.dataset.task);
+  card.classList.add('dragging');
+  ev.dataTransfer.effectAllowed = 'move';
+  ev.dataTransfer.setData('text/plain', String(dragId));
+});
+document.addEventListener('dragend', function (ev) {
+  if (ev.target.classList) ev.target.classList.remove('dragging');
+  dragId = null;
+});
+document.addEventListener('dragover', function (ev) {
+  var col = ev.target.closest ? ev.target.closest('.col[data-status]') : null;
+  if (!col || dragId === null) return;
+  ev.preventDefault();
+  ev.dataTransfer.dropEffect = 'move';
+  col.classList.add('over');
+});
+document.addEventListener('dragleave', function (ev) {
+  var col = ev.target.closest ? ev.target.closest('.col[data-status]') : null;
+  if (col) col.classList.remove('over');
+});
+document.addEventListener('drop', function (ev) {
+  var col = ev.target.closest ? ev.target.closest('.col[data-status]') : null;
+  if (!col || dragId === null) return;
+  ev.preventDefault();
+  col.classList.remove('over');
+  var id = dragId;
+  var status = col.dataset.status;
+  var current = S.tasks.filter(function (t) { return t.id === id; })[0];
+  dragId = null;
+  if (current && current.status === status) return;
+  act('task_update', { id: id, status: status })
+    .then(function () { toast('Moved to ' + label(status)); return refresh(); }).catch(oops);
+});
+
+/* ---------- boot ---------- */
+
+get('/api/projects').then(function (r) {
+  S.projects = r.projects;
+  S.readOnly = !!r.read_only;
+  el('dbpath').textContent = r.db_path;
+  el('roBadge').hidden = !S.readOnly;
+  if (S.readOnly) el('newProject').hidden = true;
+  if (S.projects.length) S.projectId = S.projects[0].id;
+  renderProjects();
+  loadProject();
+}).catch(fail);
+</script>
+</body>
+</html>`;

--- a/test/comments.test.js
+++ b/test/comments.test.js
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDbPath, loadTools, seed } from './helpers.js';
+
+const tools = await loadTools(tempDbPath('saga-comments'));
+const fixture = seed(tools);
+const taskId = fixture.tasks[0].id;
+const { keeper, doomed } = fixture.comments;
+
+test('comment_list returns live comments in order', () => {
+  const list = tools.comment_list({ task_id: taskId });
+  assert.equal(list.length, 2);
+  assert.deepEqual(list.map((c) => c.id), [keeper.id, doomed.id]);
+});
+
+test('comment_delete soft-deletes and records who and why', () => {
+  const res = tools.comment_delete({ id: doomed.id, reason: 'hallucinated API', deleted_by: 'pranab' });
+  assert.equal(res.comment.is_deleted, 1);
+  assert.equal(res.comment.delete_reason, 'hallucinated API');
+  assert.equal(res.comment.deleted_by, 'pranab');
+  assert.ok(res.comment.deleted_at, 'deleted_at should be stamped');
+  assert.equal(res.comment.content, 'This API does not exist.', 'content must survive for the audit trail');
+});
+
+test('removed comments are hidden from comment_list and task_get', () => {
+  assert.equal(tools.comment_list({ task_id: taskId }).length, 1);
+  assert.equal(tools.task_get({ id: taskId }).comments.length, 1);
+});
+
+test('include_deleted surfaces them with the reason', () => {
+  const all = tools.comment_list({ task_id: taskId, include_deleted: true });
+  assert.equal(all.length, 2);
+  const removed = all.find((c) => c.id === doomed.id);
+  assert.equal(removed.is_deleted, 1);
+  assert.equal(removed.delete_reason, 'hallucinated API');
+});
+
+test('the removal is written to the activity log', () => {
+  const entries = tools.activity_log({ limit: 50 });
+  const rows = Array.isArray(entries) ? entries : entries.activity ?? entries.entries ?? [];
+  const found = JSON.stringify(rows).includes('Comment ' + doomed.id + ' removed');
+  assert.ok(found, 'expected a "Comment N removed" entry in the activity log');
+});
+
+test('comment_delete is idempotent', () => {
+  const again = tools.comment_delete({ id: doomed.id });
+  assert.match(again.message, /already removed/);
+  assert.equal(tools.comment_list({ task_id: taskId, include_deleted: true }).length, 2);
+});
+
+test('comment_restore brings it back and clears the removal fields', () => {
+  const res = tools.comment_restore({ id: doomed.id });
+  assert.equal(res.comment.is_deleted, 0);
+  assert.equal(res.comment.deleted_at, null);
+  assert.equal(res.comment.deleted_by, null);
+  assert.equal(res.comment.delete_reason, null);
+  assert.equal(tools.comment_list({ task_id: taskId }).length, 2);
+});
+
+test('comment_restore is idempotent', () => {
+  assert.match(tools.comment_restore({ id: doomed.id }).message, /not removed/);
+});
+
+test('a missing comment id is an error, not a silent no-op', () => {
+  assert.throws(() => tools.comment_delete({ id: 999999 }), /not found/);
+  assert.throws(() => tools.comment_restore({ id: 999999 }), /not found/);
+});
+
+test('export carries the removal flags so the audit trail survives a round-trip', () => {
+  tools.comment_delete({ id: doomed.id, reason: 'wrong again' });
+  const exported = tools.tracker_export({ project_id: fixture.project.id });
+  const payload = typeof exported === 'string' ? JSON.parse(exported) : exported;
+  const json = JSON.stringify(payload);
+  assert.ok(json.includes('wrong again'), 'delete_reason should appear in the export');
+  assert.ok(json.includes('This API does not exist.'), 'removed comment content should be exported');
+});

--- a/test/global-db.test.js
+++ b/test/global-db.test.js
@@ -1,0 +1,165 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDbPath, loadTools } from './helpers.js';
+import { resetProjectScopeCache } from '../dist/helpers/project-scope.js';
+
+/**
+ * The "global" setup: one .tracker.db shared by every repo, several projects
+ * inside it. Without scoping, an agent working in one repo sees another repo's
+ * work. These tests pin the scoping rule:
+ *
+ *   explicit project_id  >  SAGA_PROJECT  >  whole database
+ */
+const t = await loadTools(tempDbPath('saga-global'));
+
+const alpha = t.project_create({ name: 'Alpha' });
+const beta = t.project_create({ name: 'Beta' });
+
+const alphaEpic = t.epic_create({ project_id: alpha.id, name: 'Alpha epic' });
+const betaEpic = t.epic_create({ project_id: beta.id, name: 'Beta epic' });
+
+const alphaTasks = ['a1', 'a2', 'a3'].map((title) =>
+  t.task_create({ epic_id: alphaEpic.id, title, description: 'alpha work' })
+);
+const betaTask = t.task_create({ epic_id: betaEpic.id, title: 'b1', description: 'beta work' });
+
+t.subtask_create({ task_id: alphaTasks[0].id, titles: ['a-sub'] });
+t.comment_add({ task_id: betaTask.id, content: 'a beta comment' });
+t.note_save({ title: 'Alpha note', content: 'alpha', related_entity_type: 'project', related_entity_id: alpha.id });
+t.note_save({ title: 'Beta note', content: 'beta', related_entity_type: 'task', related_entity_id: betaTask.id });
+t.note_save({ title: 'Floating note', content: 'belongs to no project' });
+
+const titlesOf = (rows) => rows.map((r) => r.title ?? r.name).sort();
+
+test('unscoped calls still see the whole database (backward compatible)', () => {
+  assert.equal(t.task_list({ limit: 100 }).length, 4);
+  assert.equal(t.note_list({}).length, 3);
+});
+
+test('task_list scoped by project_id only returns that project', () => {
+  assert.deepEqual(titlesOf(t.task_list({ project_id: alpha.id, limit: 100 })), ['a1', 'a2', 'a3']);
+  assert.deepEqual(titlesOf(t.task_list({ project_id: beta.id, limit: 100 })), ['b1']);
+});
+
+test('project_id composes with the other task filters', () => {
+  t.task_update({ id: alphaTasks[0].id, status: 'done' });
+  const done = t.task_list({ project_id: alpha.id, status: 'done', limit: 100 });
+  assert.deepEqual(titlesOf(done), ['a1']);
+  assert.equal(t.task_list({ project_id: beta.id, status: 'done', limit: 100 }).length, 0);
+});
+
+test('note_list scoped by project includes its epics and tasks, plus unattached notes', () => {
+  const alphaNotes = titlesOf(t.note_list({ project_id: alpha.id }));
+  assert.ok(alphaNotes.includes('Alpha note'));
+  assert.ok(alphaNotes.includes('Floating note'), 'notes attached to nothing are global');
+  assert.ok(!alphaNotes.includes('Beta note'));
+
+  const betaNotes = titlesOf(t.note_list({ project_id: beta.id }));
+  assert.ok(betaNotes.includes('Beta note'), 'a note on a task counts as that task\'s project');
+  assert.ok(!betaNotes.includes('Alpha note'));
+});
+
+test('activity_log scoped by project excludes the other project entirely', () => {
+  const alphaLog = JSON.stringify(t.activity_log({ project_id: alpha.id, limit: 200 }));
+  const betaLog = JSON.stringify(t.activity_log({ project_id: beta.id, limit: 200 }));
+  assert.ok(alphaLog.includes('Alpha'));
+  assert.ok(!alphaLog.includes('Beta epic'), 'alpha log must not mention beta');
+  assert.ok(betaLog.includes('Beta') || betaLog.includes('b1'));
+  assert.ok(!betaLog.includes('Alpha epic'), 'beta log must not mention alpha');
+});
+
+test('activity_log scoping reaches subtasks and comments, not just tasks', () => {
+  const betaLog = JSON.stringify(t.activity_log({ project_id: beta.id, limit: 200 }));
+  assert.ok(betaLog.includes('Comment'), 'a comment on a beta task belongs to beta');
+  const alphaLog = JSON.stringify(t.activity_log({ project_id: alpha.id, limit: 200 }));
+  assert.ok(alphaLog.includes('a-sub'), 'a subtask of an alpha task belongs to alpha');
+});
+
+test('tracker_search scoped by project filters every result bucket', () => {
+  const scoped = t.tracker_search({ query: 'a', project_id: alpha.id });
+  assert.ok(scoped.tasks.every((x) => alphaTasks.some((a) => a.id === x.id)));
+  assert.ok(scoped.epics.every((e) => e.project_id === alpha.id));
+  assert.ok(scoped.projects.every((p) => p.id === alpha.id));
+  assert.ok(!JSON.stringify(scoped.notes).includes('Beta note'));
+});
+
+test('tracker_dashboard scoped by project_id reports only that project', () => {
+  const d = t.tracker_dashboard({ project_id: beta.id });
+  assert.equal(d.project.name, 'Beta');
+  assert.equal(d.stats.total_tasks, 1);
+  assert.ok(!('other_projects' in d), 'an explicit scope is not a guess, so no warning');
+});
+
+test('an ambiguous dashboard says it guessed and lists the alternatives', () => {
+  const d = t.tracker_dashboard({});
+  assert.ok(d.other_projects, 'a multi-project database with no scope must flag it');
+  assert.deepEqual(titlesOf(d.other_projects), ['Beta']);
+  assert.match(d.summary, /none was specified/);
+  assert.match(d.summary, /SAGA_PROJECT/);
+});
+
+test('a single-project database gets no warning', () => {
+  const solo = t.tracker_dashboard({ project_id: alpha.id });
+  assert.ok(!('other_projects' in solo));
+});
+
+test('SAGA_PROJECT scopes every tool by id', () => {
+  process.env.SAGA_PROJECT = String(beta.id);
+  resetProjectScopeCache();
+  try {
+    assert.deepEqual(titlesOf(t.task_list({ limit: 100 })), ['b1']);
+    assert.equal(t.tracker_dashboard({}).project.name, 'Beta');
+    assert.ok(!JSON.stringify(t.note_list({})).includes('Alpha note'));
+    assert.ok(!JSON.stringify(t.activity_log({ limit: 200 })).includes('Alpha epic'));
+  } finally {
+    delete process.env.SAGA_PROJECT;
+    resetProjectScopeCache();
+  }
+});
+
+test('SAGA_PROJECT also accepts a project name, case-insensitively', () => {
+  process.env.SAGA_PROJECT = 'beta';
+  resetProjectScopeCache();
+  try {
+    assert.deepEqual(titlesOf(t.task_list({ limit: 100 })), ['b1']);
+  } finally {
+    delete process.env.SAGA_PROJECT;
+    resetProjectScopeCache();
+  }
+});
+
+test('an explicit project_id overrides SAGA_PROJECT', () => {
+  process.env.SAGA_PROJECT = String(beta.id);
+  resetProjectScopeCache();
+  try {
+    assert.deepEqual(titlesOf(t.task_list({ project_id: alpha.id, limit: 100 })), ['a1', 'a2', 'a3']);
+  } finally {
+    delete process.env.SAGA_PROJECT;
+    resetProjectScopeCache();
+  }
+});
+
+test('a SAGA_PROJECT that matches nothing fails loudly and names the real projects', () => {
+  process.env.SAGA_PROJECT = 'does-not-exist';
+  resetProjectScopeCache();
+  try {
+    assert.throws(() => t.task_list({ limit: 10 }), /not a project in this database/);
+    assert.throws(() => t.task_list({ limit: 10 }), /Alpha/);
+  } finally {
+    delete process.env.SAGA_PROJECT;
+    resetProjectScopeCache();
+  }
+});
+
+test('writes are unaffected by scoping — they are addressed by parent id', () => {
+  process.env.SAGA_PROJECT = String(beta.id);
+  resetProjectScopeCache();
+  try {
+    const created = t.task_create({ epic_id: alphaEpic.id, title: 'a4' });
+    assert.equal(t.task_get({ id: created.id }).title, 'a4');
+    assert.deepEqual(titlesOf(t.task_list({ project_id: alpha.id, limit: 100 })), ['a1', 'a2', 'a3', 'a4']);
+  } finally {
+    delete process.env.SAGA_PROJECT;
+    resetProjectScopeCache();
+  }
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Each test file gets its own database in its own temp directory. `node --test`
+ * runs one process per file, so the module-level connection in db.js stays
+ * isolated between files.
+ */
+export function tempDbPath(name = 'saga-test') {
+  const dir = mkdtempSync(join(tmpdir(), name + '-'));
+  const path = join(dir, '.tracker.db');
+  process.on('exit', () => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* the OS will clean the temp dir up eventually */
+    }
+  });
+  return path;
+}
+
+/** Import the built tool handlers against a given database. */
+export async function loadTools(dbPath) {
+  process.env.DB_PATH = dbPath;
+  const load = (m) => import('../dist/tools/' + m + '.js');
+  const [projects, epics, tasks, subtasks, notes, comments, dashboard, activity, templates, search, exportImport] =
+    await Promise.all([
+      load('projects'), load('epics'), load('tasks'), load('subtasks'), load('notes'),
+      load('comments'), load('dashboard'), load('activity'), load('templates'),
+      load('search'), load('export-import'),
+    ]);
+  return {
+    ...projects.handlers, ...epics.handlers, ...tasks.handlers, ...subtasks.handlers,
+    ...notes.handlers, ...comments.handlers, ...dashboard.handlers, ...activity.handlers,
+    ...templates.handlers, ...search.handlers, ...exportImport.handlers,
+  };
+}
+
+/** Every tool definition the server knows about. */
+export async function loadDefinitions() {
+  const mods = ['projects', 'epics', 'tasks', 'subtasks', 'notes', 'comments',
+                'templates', 'dashboard', 'search', 'activity', 'export-import'];
+  const out = [];
+  for (const m of mods) out.push(...(await import('../dist/tools/' + m + '.js')).definitions);
+  return out;
+}
+
+/**
+ * A small but realistic project: 2 epics, 6 tasks across every status,
+ * subtasks, comments and a note.
+ */
+export function seed(t, opts = {}) {
+  const longDescription = opts.longDescription ?? false;
+  const project = t.project_create({ name: 'Payments', description: 'Billing and reconciliation.' });
+  const billing = t.epic_create({
+    project_id: project.id, name: 'Billing core', status: 'in_progress', priority: 'high',
+  });
+  const reporting = t.epic_create({ project_id: project.id, name: 'Reporting', priority: 'low' });
+
+  const statuses = ['todo', 'in_progress', 'review', 'done', 'blocked', 'todo'];
+  const tasks = statuses.map((status, i) =>
+    t.task_create({
+      epic_id: i % 2 === 0 ? billing.id : reporting.id,
+      title: `Task ${i + 1}: the ${['charge', 'refund', 'webhook', 'ledger', 'export', 'retry'][i]} path`,
+      description: longDescription
+        ? 'Walk the settlement file, match each line against the ledger by provider reference, ' +
+          'flag anything past the tolerance threshold, and write an exception row for review. ' +
+          'Must be idempotent so a re-run after a partial failure does not double-post.'
+        : 'Short note.',
+      status,
+      priority: ['low', 'medium', 'high', 'critical'][i % 4],
+      estimated_hours: i + 1,
+    })
+  );
+
+  t.subtask_create({ task_id: tasks[0].id, titles: ['Write it', 'Test it', 'Document it'] });
+  const keeper = t.comment_add({ task_id: tasks[0].id, content: 'Provider needs an idempotency key.', author: 'agent' });
+  const doomed = t.comment_add({ task_id: tasks[0].id, content: 'This API does not exist.', author: 'agent' });
+  t.note_save({
+    title: 'Scope decision', content: 'Chose A over B: one fewer round trip.',
+    note_type: 'decision', related_entity_type: 'project', related_entity_id: project.id,
+  });
+
+  return { project, epics: { billing, reporting }, tasks, comments: { keeper, doomed } };
+}

--- a/test/migration.test.js
+++ b/test/migration.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { tempDbPath } from './helpers.js';
+
+/**
+ * Opening a database written by an older saga-mcp must upgrade it in place.
+ * SCHEMA_SQL runs before the ALTER TABLE migrations, so anything in SCHEMA_SQL
+ * that references a migrated column would throw here and take the whole server
+ * down for every existing user — this test is the guard against that.
+ */
+const dbPath = tempDbPath('saga-migration');
+
+const legacy = new Database(dbPath);
+legacy.exec(`
+  CREATE TABLE projects (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT,
+    status TEXT NOT NULL DEFAULT 'active', tags TEXT NOT NULL DEFAULT '[]', metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE epics (id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER NOT NULL, name TEXT NOT NULL,
+    description TEXT, status TEXT NOT NULL DEFAULT 'planned', priority TEXT NOT NULL DEFAULT 'medium',
+    sort_order INTEGER NOT NULL DEFAULT 0, tags TEXT NOT NULL DEFAULT '[]', metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, epic_id INTEGER NOT NULL, title TEXT NOT NULL,
+    description TEXT, status TEXT NOT NULL DEFAULT 'todo', priority TEXT NOT NULL DEFAULT 'medium',
+    sort_order INTEGER NOT NULL DEFAULT 0, assigned_to TEXT, estimated_hours REAL, actual_hours REAL,
+    due_date TEXT, tags TEXT NOT NULL DEFAULT '[]', metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE comments (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, author TEXT,
+    content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')));
+  INSERT INTO projects (name) VALUES ('Legacy');
+  INSERT INTO epics (project_id, name) VALUES (1, 'Legacy epic');
+  INSERT INTO tasks (epic_id, title) VALUES (1, 'Legacy task');
+  INSERT INTO comments (task_id, author, content) VALUES (1, 'old', 'written before the upgrade');
+`);
+const legacyColumns = legacy.prepare('SELECT * FROM comments').columns().map((c) => c.name);
+legacy.close();
+
+process.env.DB_PATH = dbPath;
+const { getDb } = await import('../dist/db.js');
+const { handlers: comments } = await import('../dist/tools/comments.js');
+
+test('the fixture really is a pre-soft-delete database', () => {
+  assert.ok(!legacyColumns.includes('is_deleted'));
+});
+
+test('opening an old database adds the soft-delete columns instead of throwing', () => {
+  const db = getDb();
+  const columns = db.prepare('SELECT * FROM comments').columns().map((c) => c.name);
+  for (const col of ['is_deleted', 'deleted_at', 'deleted_by', 'delete_reason']) {
+    assert.ok(columns.includes(col), `expected migrated column ${col}`);
+  }
+});
+
+test('rows written before the upgrade default to not-deleted', () => {
+  const row = getDb().prepare('SELECT * FROM comments WHERE id = 1').get();
+  assert.equal(row.is_deleted, 0);
+  assert.equal(row.content, 'written before the upgrade');
+});
+
+test('pre-existing comments still list, and soft-delete works on them', () => {
+  assert.equal(comments.comment_list({ task_id: 1 }).length, 1);
+  comments.comment_delete({ id: 1, reason: 'migrated then removed' });
+  assert.equal(comments.comment_list({ task_id: 1 }).length, 0);
+  assert.equal(comments.comment_list({ task_id: 1, include_deleted: true }).length, 1);
+});
+
+test('opening the upgraded database a second time is a no-op', () => {
+  assert.doesNotThrow(() => getDb().prepare('SELECT is_deleted FROM comments').all());
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,128 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tempDbPath, loadTools, seed } from './helpers.js';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dbPath = tempDbPath('saga-stdio');
+seed(await loadTools(dbPath));
+
+/** Speak JSON-RPC to a freshly spawned MCP server over stdio. */
+function startServer(env = {}) {
+  const child = spawn(process.execPath, ['dist/index.js'], {
+    cwd: root,
+    env: { ...process.env, DB_PATH: dbPath, SAGA_TOOLS: '', ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  let stderr = '';
+  child.stderr.on('data', (d) => (stderr += d.toString()));
+
+  let buffer = '';
+  const pending = new Map();
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk.toString();
+    let nl;
+    while ((nl = buffer.indexOf('\n')) >= 0) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      if (!line.trim()) continue;
+      const msg = JSON.parse(line);
+      const resolve = pending.get(msg.id);
+      if (resolve) { pending.delete(msg.id); resolve(msg); }
+    }
+  });
+
+  let id = 0;
+  const send = (method, params) =>
+    new Promise((resolve) => {
+      const myId = ++id;
+      pending.set(myId, resolve);
+      child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: myId, method, params }) + '\n');
+    });
+
+  const ready = (async () => {
+    await send('initialize', {
+      protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '1' },
+    });
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+  })();
+
+  return { child, send, ready, stderr: () => stderr, stop: () => child.kill() };
+}
+
+const servers = [];
+async function server(env) {
+  const s = startServer(env);
+  servers.push(s);
+  await s.ready;
+  return s;
+}
+after(() => servers.forEach((s) => s.stop()));
+
+test('tools/list returns every tool by default', async () => {
+  const s = await server();
+  const res = await s.send('tools/list', {});
+  assert.equal(res.result.tools.length, 33);
+});
+
+test('SAGA_TOOLS=core lists only the core surface, and it is much smaller', async () => {
+  const full = await server();
+  const core = await server({ SAGA_TOOLS: 'core' });
+  const fullTools = (await full.send('tools/list', {})).result.tools;
+  const coreTools = (await core.send('tools/list', {})).result.tools;
+
+  assert.equal(coreTools.length, 12);
+  assert.ok(coreTools.every((t) => fullTools.some((f) => f.name === t.name)), 'core must be a subset');
+  for (const required of ['tracker_dashboard', 'task_create', 'task_list', 'task_get', 'task_update']) {
+    assert.ok(coreTools.some((t) => t.name === required), `core is missing ${required}`);
+  }
+  const ratio = JSON.stringify(coreTools).length / JSON.stringify(fullTools).length;
+  assert.ok(ratio < 0.6, `core should be well under half the full list, got ${ratio.toFixed(2)}`);
+});
+
+test('a tool left off the core list is still callable by name', async () => {
+  const s = await server({ SAGA_TOOLS: 'core' });
+  const listed = (await s.send('tools/list', {})).result.tools.map((t) => t.name);
+  assert.ok(!listed.includes('template_list'), 'precondition: template_list is not core');
+  const res = await s.send('tools/call', { name: 'template_list', arguments: {} });
+  assert.ok(!res.result.isError, 'unlisted tools must still work when called directly');
+});
+
+test('an unrecognised SAGA_TOOLS value warns and falls back to the full list', async () => {
+  const s = await server({ SAGA_TOOLS: 'nonsense' });
+  const res = await s.send('tools/list', {});
+  assert.equal(res.result.tools.length, 33);
+  assert.match(s.stderr(), /Unknown SAGA_TOOLS/);
+});
+
+test('tool results are compact JSON, not pretty-printed', async () => {
+  const s = await server();
+  const res = await s.send('tools/call', { name: 'tracker_dashboard', arguments: {} });
+  const text = res.result.content[0].text;
+  assert.doesNotThrow(() => JSON.parse(text), 'still valid JSON');
+  assert.ok(!/\n\s\s/.test(text), 'no indentation');
+});
+
+test('errors come back as readable text, not a JSON blob', async () => {
+  const s = await server();
+  const res = await s.send('tools/call', { name: 'task_get', arguments: { id: 999999 } });
+  assert.ok(res.result.isError);
+  assert.match(res.result.content[0].text, /Task 999999 not found/);
+});
+
+test('an unknown tool name is an error, not a crash', async () => {
+  const s = await server();
+  const res = await s.send('tools/call', { name: 'no_such_tool', arguments: {} });
+  assert.ok(res.result.isError);
+  assert.match(res.result.content[0].text, /Unknown tool/);
+});
+
+test('a round trip through the server actually reads the database', async () => {
+  const s = await server();
+  const res = await s.send('tools/call', { name: 'task_list', arguments: {} });
+  const rows = JSON.parse(res.result.content[0].text);
+  assert.equal(rows.length, 6);
+  assert.ok(rows.every((r) => !('metadata' in r)), 'list rows stay slim over the wire');
+});

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -1,0 +1,145 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDbPath, loadTools, loadDefinitions, seed } from './helpers.js';
+import { truncate, slimListRow, LIST_DESCRIPTION_CHARS } from '../dist/helpers/slim.js';
+
+const tools = await loadTools(tempDbPath('saga-tokens'));
+seed(tools, { longDescription: true });
+
+test('truncate leaves short text alone', () => {
+  assert.equal(truncate('short'), 'short');
+});
+
+test('truncate cuts long text at a word boundary with an ellipsis', () => {
+  const out = truncate('a'.repeat(10) + ' ' + 'word '.repeat(60));
+  assert.ok(out.length <= LIST_DESCRIPTION_CHARS + 1, 'stays within the cap');
+  assert.ok(out.endsWith('…'), 'signals that it was cut');
+  assert.ok(!out.includes('  '), 'no dangling whitespace before the ellipsis');
+});
+
+test('truncate falls back to a hard cut when there is no usable space', () => {
+  const out = truncate('x'.repeat(400));
+  assert.equal(out.length, LIST_DESCRIPTION_CHARS + 1);
+  assert.ok(out.endsWith('…'));
+});
+
+test('slimListRow drops nulls, metadata and empty tags but keeps real values', () => {
+  const row = slimListRow({
+    id: 1, title: 'Keep me', description: 'short', due_date: null,
+    metadata: '{}', tags: '[]', assigned_to: 'agent', estimated_hours: 0,
+  });
+  assert.deepEqual(Object.keys(row).sort(), ['assigned_to', 'description', 'estimated_hours', 'id', 'title']);
+  assert.equal(row.estimated_hours, 0, 'zero is a real value, not a null');
+});
+
+test('slimListRow keeps non-empty tags', () => {
+  const row = slimListRow({ id: 1, tags: '["billing"]' });
+  assert.equal(row.tags, '["billing"]');
+});
+
+test('task_list rows are slimmed', () => {
+  const rows = tools.task_list({});
+  assert.ok(rows.length > 0);
+  for (const row of rows) {
+    assert.ok(!('metadata' in row), 'metadata should never appear in a list row');
+    for (const [key, value] of Object.entries(row)) {
+      assert.notEqual(value, null, `${key} should be omitted rather than null`);
+    }
+    if (typeof row.description === 'string') {
+      assert.ok(row.description.length <= LIST_DESCRIPTION_CHARS + 1);
+    }
+  }
+});
+
+test('task_list truncates but task_get keeps the full description', () => {
+  const listed = tools.task_list({}).find((r) => r.description?.endsWith('…'));
+  assert.ok(listed, 'the long-description fixture should produce a truncated row');
+  const full = tools.task_get({ id: listed.id });
+  assert.ok(full.description.length > LIST_DESCRIPTION_CHARS);
+  assert.ok(!full.description.endsWith('…'));
+});
+
+test('slimming measurably shrinks the payload', () => {
+  const slim = JSON.stringify(tools.task_list({})).length;
+  const full = JSON.stringify(tools.task_list({}).map((r) => ({ ...r, metadata: '{}' }))).length;
+  assert.ok(slim < full);
+  // Guard the headline claim: a long-description project should shrink a lot.
+  const rows = tools.task_list({});
+  const rawish = rows.reduce((n, r) => n + JSON.stringify(tools.task_get({ id: r.id })).length, 0);
+  assert.ok(slim < rawish * 0.6, `expected the list to be well under the sum of details (${slim} vs ${rawish})`);
+});
+
+test('every tool definition carries safety annotations', async () => {
+  const defs = await loadDefinitions();
+  assert.equal(defs.length, 33);
+  for (const def of defs) {
+    assert.ok(def.annotations, `${def.name} is missing annotations`);
+    assert.equal(typeof def.annotations.readOnlyHint, 'boolean', `${def.name} readOnlyHint`);
+    assert.ok(def.description.length > 0, `${def.name} needs a description`);
+  }
+});
+
+test('read-only tools are annotated as such', async () => {
+  const defs = await loadDefinitions();
+  const byName = Object.fromEntries(defs.map((d) => [d.name, d]));
+  for (const name of ['task_get', 'task_list', 'comment_list', 'tracker_dashboard', 'epic_list']) {
+    assert.equal(byName[name].annotations.readOnlyHint, true, `${name} should be readOnly`);
+  }
+  for (const name of ['task_create', 'comment_delete', 'comment_restore', 'epic_update']) {
+    assert.equal(byName[name].annotations.readOnlyHint, false, `${name} should not be readOnly`);
+  }
+});
+
+test('the tool list stays within its context budget', async () => {
+  const defs = await loadDefinitions();
+  const bytes = JSON.stringify(defs).length;
+  // ~6k tokens. If this fails, a tool description grew — trim it or move the
+  // tool out of the core set rather than raising the ceiling.
+  assert.ok(bytes < 25000, `tool list is ${bytes} bytes, over the 25000 budget`);
+});
+
+test('activity_log drops the row id and null columns', () => {
+  const rows = tools.activity_log({ limit: 50 });
+  assert.ok(rows.length > 0);
+  for (const row of rows) {
+    assert.ok(!('id' in row), 'no tool takes an activity id, so it is dead weight');
+    for (const [key, value] of Object.entries(row)) {
+      assert.notEqual(value, null, `${key} should be omitted rather than null`);
+    }
+  }
+  assert.ok(rows.some((r) => r.summary), 'the readable summary must survive');
+});
+
+test('tracker_search returns previews, not whole records', () => {
+  const results = tools.tracker_search({ query: 'the' });
+  for (const task of results.tasks) {
+    assert.ok(!('metadata' in task));
+    if (typeof task.description === 'string') {
+      assert.ok(task.description.length <= LIST_DESCRIPTION_CHARS + 1);
+    }
+  }
+  for (const note of results.notes) {
+    assert.ok(note.content.length <= LIST_DESCRIPTION_CHARS + 1, 'note content is previewed in search');
+  }
+});
+
+test('note_list keeps full note content — it is the retrieval tool, not a preview', () => {
+  const long = 'x'.repeat(LIST_DESCRIPTION_CHARS * 3);
+  tools.note_save({ title: 'Long note', content: long, note_type: 'context' });
+  const found = tools.note_list({}).find((n) => n.title === 'Long note');
+  assert.equal(found.content.length, long.length);
+});
+
+test('list responses carry no null padding anywhere', () => {
+  const sets = [
+    ['epic_list', tools.epic_list({ project_id: 1 })],
+    ['project_list', tools.project_list({})],
+  ];
+  for (const [name, rows] of sets) {
+    for (const row of rows) {
+      for (const [key, value] of Object.entries(row)) {
+        assert.notEqual(value, null, `${name}.${key} should be omitted rather than null`);
+      }
+    }
+  }
+});

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -1,0 +1,231 @@
+import { test, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { tempDbPath, loadTools, seed } from './helpers.js';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const dbPath = tempDbPath('saga-web');
+const fixture = seed(await loadTools(dbPath));
+
+const running = [];
+after(() => running.forEach((c) => c.kill()));
+
+/** Start saga-web and wait for it to print the URL it actually bound. */
+function startWeb(args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, ['dist/web/index.js', dbPath, ...args], {
+      cwd: root,
+      env: { ...process.env, SAGA_WEB_PORT: '', PORT: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    running.push(child);
+    let out = '';
+    const timer = setTimeout(() => reject(new Error('saga-web did not start: ' + out)), 15000);
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      const m = out.match(/saga-web\s+(http:\/\/\S+)/);
+      if (m) {
+        clearTimeout(timer);
+        resolve({ child, base: m[1], output: () => out });
+      }
+    });
+    child.stderr.on('data', (d) => (out += d.toString()));
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`saga-web exited with ${code}: ${out}`));
+    });
+  });
+}
+
+const post = (base, body, headers = {}) =>
+  fetch(base + '/api/action', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-saga-ui': '1', ...headers },
+    body: JSON.stringify(body),
+  });
+
+const editable = await startWeb();
+
+test('serves the page', async () => {
+  const res = await fetch(editable.base + '/');
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type'), /text\/html/);
+  const html = await res.text();
+  assert.ok(html.includes('<title>Saga</title>'));
+  assert.ok(html.includes('/api/action'), 'the page must know where to write');
+});
+
+test('lists projects with the database path and mode', async () => {
+  const body = await (await fetch(editable.base + '/api/projects')).json();
+  assert.equal(body.read_only, false);
+  assert.ok(body.db_path.endsWith('.tracker.db'));
+  assert.equal(body.projects.length, 1);
+  assert.equal(body.projects[0].name, 'Payments');
+});
+
+test('overview returns stats, epics and overdue/blocked buckets', async () => {
+  const o = await (await fetch(`${editable.base}/api/overview?project_id=${fixture.project.id}`)).json();
+  assert.equal(o.project.name, 'Payments');
+  assert.equal(o.stats.total_tasks, 6);
+  assert.equal(o.epics.length, 2);
+  assert.equal(o.blocked_tasks.length, 1);
+});
+
+test('overview rejects a missing or unknown project', async () => {
+  assert.equal((await fetch(editable.base + '/api/overview')).status, 400);
+  assert.equal((await fetch(editable.base + '/api/overview?project_id=4242')).status, 404);
+});
+
+test('task detail includes subtasks, comments and history', async () => {
+  const t = await (await fetch(`${editable.base}/api/tasks/${fixture.tasks[0].id}`)).json();
+  assert.equal(t.subtasks.length, 3);
+  assert.equal(t.comments.length, 2);
+  assert.equal(t.deleted_comment_count, 0);
+  assert.ok(Array.isArray(t.activity));
+});
+
+test('search needs two characters and finds tasks', async () => {
+  const empty = await (await fetch(editable.base + '/api/search?q=a')).json();
+  assert.equal(empty.tasks.length, 0);
+  const hit = await (await fetch(editable.base + '/api/search?q=charge')).json();
+  assert.ok(hit.tasks.length >= 1);
+});
+
+test('unknown routes 404', async () => {
+  assert.equal((await fetch(editable.base + '/api/nope')).status, 404);
+});
+
+test('a write goes through and is visible on the next read', async () => {
+  const res = await post(editable.base, {
+    tool: 'task_update',
+    args: { id: fixture.tasks[0].id, status: 'done', priority: 'critical' },
+  });
+  assert.equal(res.status, 200);
+  const t = await (await fetch(`${editable.base}/api/tasks/${fixture.tasks[0].id}`)).json();
+  assert.equal(t.status, 'done');
+  assert.equal(t.priority, 'critical');
+});
+
+test('UI edits land in the same activity log as agent edits', async () => {
+  const { activity } = await (await fetch(editable.base + '/api/activity?limit=50')).json();
+  assert.ok(
+    activity.some((a) => /status: \w+ -> done/.test(a.summary ?? '')),
+    'the status change made through the UI should be logged'
+  );
+});
+
+test('comment removal and restore work through the UI path', async () => {
+  const id = fixture.comments.doomed.id;
+  await post(editable.base, { tool: 'comment_delete', args: { id, reason: 'wrong', deleted_by: 'ui' } });
+
+  const hidden = await (await fetch(`${editable.base}/api/tasks/${fixture.tasks[0].id}`)).json();
+  assert.equal(hidden.comments.length, 1);
+  assert.equal(hidden.deleted_comment_count, 1);
+
+  const shown = await (await fetch(`${editable.base}/api/tasks/${fixture.tasks[0].id}?include_deleted=1`)).json();
+  const removed = shown.comments.find((c) => c.id === id);
+  assert.equal(removed.is_deleted, 1);
+  assert.equal(removed.delete_reason, 'wrong');
+
+  await post(editable.base, { tool: 'comment_restore', args: { id } });
+  const back = await (await fetch(`${editable.base}/api/tasks/${fixture.tasks[0].id}`)).json();
+  assert.equal(back.comments.length, 2);
+});
+
+test('a write without the UI header is refused', async () => {
+  const res = await fetch(editable.base + '/api/action', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ tool: 'task_update', args: { id: 1, status: 'todo' } }),
+  });
+  assert.equal(res.status, 403);
+  assert.match((await res.json()).error, /x-saga-ui/);
+});
+
+test('a write from another origin is refused', async () => {
+  const res = await post(editable.base, { tool: 'task_update', args: { id: 1, status: 'todo' } },
+                         { origin: 'https://evil.example' });
+  assert.equal(res.status, 403);
+  assert.match((await res.json()).error, /Cross-origin/);
+});
+
+test('a same-origin write is allowed', async () => {
+  const res = await post(editable.base, { tool: 'task_update', args: { id: fixture.tasks[1].id, status: 'review' } },
+                         { origin: editable.base });
+  assert.equal(res.status, 200);
+});
+
+test('only whitelisted tools can be invoked', async () => {
+  for (const tool of ['tracker_import', 'constructor', '__proto__', 'toString', '']) {
+    const res = await post(editable.base, { tool, args: {} });
+    assert.equal(res.status, 400, `${tool} should be refused`);
+    assert.match((await res.json()).error, /Unknown or disallowed/);
+  }
+});
+
+test('a failing tool returns its message rather than a stack trace', async () => {
+  const res = await post(editable.base, { tool: 'task_update', args: { id: 999999, status: 'done' } });
+  assert.equal(res.status, 400);
+  assert.match((await res.json()).error, /Task 999999 not found/);
+});
+
+test('a malformed body is a 400', async () => {
+  const res = await fetch(editable.base + '/api/action', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-saga-ui': '1' },
+    body: 'not json',
+  });
+  assert.equal(res.status, 400);
+});
+
+test('--read-only serves reads and refuses every write', async () => {
+  const ro = await startWeb(['--read-only']);
+  const body = await (await fetch(ro.base + '/api/projects')).json();
+  assert.equal(body.read_only, true);
+  assert.equal((await fetch(`${ro.base}/api/overview?project_id=${fixture.project.id}`)).status, 200);
+  const res = await post(ro.base, { tool: 'task_update', args: { id: 1, status: 'todo' } });
+  assert.equal(res.status, 403);
+  assert.match((await res.json()).error, /read-only/);
+});
+
+test('a second instance takes the next free port instead of failing', async () => {
+  const second = await startWeb();
+  const third = await startWeb();
+  const ports = [editable.base, second.base, third.base].map((u) => Number(new URL(u).port));
+  assert.equal(new Set(ports).size, 3, `expected three distinct ports, got ${ports.join(', ')}`);
+  assert.ok(second.output().includes('took the next free port'), 'should say why it moved');
+  // and each one actually serves
+  for (const base of [second.base, third.base]) {
+    assert.equal((await fetch(base + '/api/projects')).status, 200);
+  }
+});
+
+test('an explicit --port is honoured exactly', async () => {
+  const pinned = await startWeb(['--port', '4457']);
+  assert.equal(new URL(pinned.base).port, '4457');
+});
+
+test('--port 0 lets the OS choose', async () => {
+  const any = await startWeb(['--port', '0']);
+  assert.ok(Number(new URL(any.base).port) > 0);
+});
+
+test('a taken explicit port fails loudly rather than moving', async () => {
+  await assert.rejects(startWeb(['--port', '4457']), /already in use|exited with 1/);
+});
+
+test('a missing database is refused, not created', async () => {
+  const child = spawn(process.execPath, ['dist/web/index.js', join(root, 'definitely-not-here.db')], {
+    cwd: root, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  running.push(child);
+  const out = await new Promise((resolve) => {
+    let buf = '';
+    child.stdout.on('data', (d) => (buf += d));
+    child.stderr.on('data', (d) => (buf += d));
+    child.on('exit', () => resolve(buf));
+  });
+  assert.match(out, /Database not found/);
+});


### PR DESCRIPTION
Closes #15. Closes #16.

Both issues were opened by @rusak47, who then did the harder half of the work in the threads — pushing back on a wrong claim I made about multi-project support, choosing soft delete over hard delete on the reasoning that both failure modes are an agent acting unsupervised, and describing the actual workflow (sketch a spec, review it, then let the agent run) that made the shape of the UI obvious. Thank you.

## What is in it

### Comment soft delete (#16)

`comment_delete` marks a comment removed instead of destroying it: `is_deleted`, `deleted_at`, `deleted_by`, `delete_reason`. `comment_list` and `task_get` skip removed comments, `include_deleted` shows them with the reason, `comment_restore` reverses it. Both directions are idempotent and logged. Export and import carry the flags.

The reasoning, from the thread: a hard delete moves the risk rather than removing it. The failure mode you want fixed (a wrong comment lingering) and the one soft delete guards against (a good comment vanishing) are both an agent acting without supervision.

### saga-web (#15)

A local web UI over the same `.tracker.db`. Overview, kanban board with drag-to-change-status, epic tree, notes, activity, search, and a task drawer that edits any field, ticks subtasks, comments, and removes or restores comments. Project switcher covers every project in the file.

```bash
npx -p saga-mcp saga-web ./.tracker.db --open
```

Writes POST to `/api/action`, which dispatches to **the same handler functions the MCP tools use**. The alternative was a second REST layer with its own SQL — two validation paths, two ways to forget an activity log entry. Sharing the handlers means an agent calling `tracker_dashboard` after a human fixes something sees both the fix and how it happened.

Binds `127.0.0.1`, no authentication, refuses cross-origin writes, only invokes a whitelist of 15 write tools, will not create a database. `--read-only` removes every editing control. Omit `--port` and it takes the first free port from 4319 up, so one instance per project works; `--port N` binds exactly N and fails if taken.

No new dependencies — `node:http` and one self-contained page.

### Cross-project leakage on a shared database

Found while checking whether the UI supported the centralized setup. On a three-project database:

| Call | Before | After |
|---|---|---|
| `task_list({})` | tasks from **all** projects, no `project_id` filter existed | scopeable; unscoped unchanged |
| `tracker_dashboard({})` | silently picked whichever project was first | says it guessed, returns `other_projects` |
| `note_list`, `activity_log`, `tracker_search` | whole file | scopeable |

An agent in one repo could see and act on another's work. The dashboard one was worse, because nothing looked broken.

One rule now, everywhere: **explicit `project_id` > `SAGA_PROJECT` > whole database**. Set `SAGA_PROJECT` per repo (id or name) and a shared file behaves exactly like a per-project one. Entirely additive — unscoped calls return what they always did.

### Token cost

Measured on a 40-task project, not estimated.

| Change | Effect |
|---|---|
| Responses no longer pretty-printed | **20-27% off every response** |
| `task_list` rows slimmed, descriptions previewed | -19% short, **-39%** realistic |
| `tracker_search` returns previews | **-47%** |
| `activity_log` drops nulls and the unusable row id | **-27%** |
| `SAGA_TOOLS=core` lists 12 of 33 tools | ~6,000 → ~2,700 tokens **per session** |

`note_list` deliberately keeps full content — it is the retrieval tool, not a preview. Detail tools (`task_get`) are untouched.

The tiered tool surface is opt-in and non-breaking; unlisted tools stay callable by name, so it is a context measure rather than an access boundary.

## Tests

76 tests on `node:test`, no new dependencies:

- **comments** — soft-delete lifecycle, idempotency, export round trip
- **migration** — a real pre-1.7 database upgrading in place
- **tokens** — truncation edges, slimming, and a byte budget that fails if tool descriptions creep back up
- **server** — MCP over stdio: tiering, compact JSON, unlisted-but-callable
- **web** — HTTP API, CSRF guards, write whitelist incl. `__proto__`, read-only mode, port scanning
- **global-db** — project scoping and its precedence

Verified from a fresh clone: install, build, 76/76 green.

## Worth reviewing carefully

1. **`/api/action` dispatching to MCP handlers** — the central design call.
2. **The migration ordering.** `SCHEMA_SQL` runs before the `ALTER TABLE`s in `db.ts`. I first put the new index in `SCHEMA_SQL` and it threw `no such column: is_deleted` on every existing database. `test/migration.test.js` is the permanent guard.
3. **`tracker_dashboard` now returns `other_projects`** on an ambiguous call — a response-shape addition, though only in the case that was previously silently wrong.

## Not in scope

Cross-*file* aggregation of separate `.tracker.db` files. One shared database with several project rows works today; a registry over separate files does not exist yet, and per the thread, smaller ships first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
