### PR TITLE
ci: run the tests, and run them before publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: [20, 22, 24]
+    name: ${{ matrix.os }} · node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build
+
+      # The suite starts real servers and binds real ports, so give it room.
+      - run: node --test
+        timeout-minutes: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.7.0)'
+        required: true
 
 jobs:
   publish:
@@ -13,14 +18,47 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+          cache: npm
 
       - run: npm ci
       - run: npm run build
-      - run: npm publish --access public --provenance
+
+      # Publishing is irreversible — a version number can never be reused — so
+      # the suite runs first. This is the only gate before the registry.
+      - name: Test
+        run: node --test
+        timeout-minutes: 5
+
+      # Catch the tag/package.json mismatch before it reaches npm, where the
+      # error is a confusing 404 rather than "you tagged the wrong version".
+      - name: Check the tag matches package.json
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          PKG="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag $TAG does not match package.json ($PKG). Bump the version or retag."
+            exit 1
+          fi
+          echo "Publishing $PKG"
+
+      - name: Publish
+        run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Explain a failed publish
+        if: failure()
+        run: |
+          echo "::notice::If this failed with 'E404 ... PUT https://registry.npmjs.org/saga-mcp',"
+          echo "::notice::the NPM_TOKEN secret is expired or lacks publish rights — npm returns 404"
+          echo "::notice::rather than 403 so it does not disclose whether a package exists."
+          echo "::notice::Mint a new automation token at npmjs.com/settings/~/tokens, then:"
+          echo "::notice::  gh secret set NPM_TOKEN"
+          echo "::notice::and re-run this workflow."


### PR DESCRIPTION
The v1.7.0 publish failed. Not the code — `npm ci`, `npm run build` and the pack all succeeded, and it died on the last step:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/saga-mcp
```

A 404 publishing to a package that exists is npm saying *unauthorized*; it returns 404 instead of 403 so it does not disclose whether a package exists. The `NPM_TOKEN` secret dates from 2026-02-28, and npm granular tokens cap at 90 days. **That needs a new token — this PR does not fix it.**

What it does fix is that the failure was harder to read than it needed to be, and that the workflow would happily have published untested code.

- **`ci.yml`** — build and test on every push and PR, Node 20/22/24, Linux and Windows. There was no suite when the publish workflow was written; there is one now.
- **`publish.yml`** — runs the suite *before* `npm publish`. Publishing is the one irreversible step in a release, so it should be the last thing that happens.
- **Tag/version check** — tagging `v1.7.0` while `package.json` says `1.6.0` currently surfaces at npm as the same confusing 404. Now it fails early saying exactly that.
- **A failure notice** spelling out the expired-token diagnosis, so the next person does not have to reason it out from a 404.
- **`workflow_dispatch`** — so a release whose publish failed can be retried against its existing tag, instead of deleting and re-pushing the tag.

### To actually publish v1.7.0

```bash
# new automation token at npmjs.com/settings/~/tokens
gh secret set NPM_TOKEN
gh workflow run "Publish to npm" -f tag=v1.7.0
```

The tag and GitHub release for v1.7.0 are already in place, so nothing needs re-tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
