### PR TITLE
ci: publish on release, not on tag; verify the tarball first

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,25 @@
 name: Publish to npm
 
+# Publishing is triggered by PUBLISHING A RELEASE, not by pushing a tag.
+#
+# Pushing a tag used to publish immediately, which put the irreversible step
+# first: the package was on npm before anyone had looked at the tagged build.
+# A version number can never be reused, so that ordering was backwards.
+#
+# The flow is now:
+#   1. tag the commit and push the tag        (nothing is published)
+#   2. verify the tagged build — npm run e2e  (packs and tests the real tarball)
+#   3. publish a GitHub release for that tag  (this fires the publish)
+#
+# Step 3 is the deliberate act. Draft releases do not trigger anything, so a
+# draft can sit while step 2 runs.
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag to publish (e.g. v1.7.0)'
+        description: 'Tag to publish (e.g. v1.8.1) — for retrying a failed publish'
         required: true
 
 jobs:
@@ -17,9 +29,26 @@ jobs:
       contents: read
       id-token: write
     steps:
+      - name: Work out what we are publishing
+        id: target
+        run: |
+          TAG="${{ github.event.inputs.tag || github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            echo "::error::No tag to publish. This workflow runs on a published release, or on manual dispatch with a tag."
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # A GitHub pre-release goes to the `next` dist-tag so it never becomes
+          # what `npm install saga-mcp` gives people by default.
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            echo "npm_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: ${{ steps.target.outputs.tag }}
 
       - uses: actions/setup-node@v4
         with:
@@ -30,26 +59,36 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      # Publishing is irreversible — a version number can never be reused — so
-      # the suite runs first. This is the only gate before the registry.
+      # The suite runs against the tagged build, not the branch tip.
       - name: Test
         run: node --test
         timeout-minutes: 5
 
-      # Catch the tag/package.json mismatch before it reaches npm, where the
-      # error is a confusing 404 rather than "you tagged the wrong version".
+      # Catch a tag/package.json mismatch here, where the message is clear.
+      # npm reports it as the same confusing 404 it uses for auth failures.
       - name: Check the tag matches package.json
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG="${{ steps.target.outputs.tag }}"
           PKG="v$(node -p "require('./package.json').version")"
           if [ "$TAG" != "$PKG" ]; then
             echo "::error::Tag $TAG does not match package.json ($PKG). Bump the version or retag."
             exit 1
           fi
-          echo "Publishing $PKG"
+          echo "Publishing $PKG to the '${{ steps.target.outputs.npm_tag }}' dist-tag"
+
+      # Refuse to republish a version that already exists, rather than letting
+      # npm answer with a 403 that reads like an auth problem.
+      - name: Check the version is not already published
+        run: |
+          PKG="$(node -p "require('./package.json').version")"
+          if npm view "saga-mcp@$PKG" version >/dev/null 2>&1; then
+            echo "::error::saga-mcp@$PKG is already on npm. A published version cannot be replaced — bump the version and tag again."
+            exit 1
+          fi
+          echo "saga-mcp@$PKG is not yet published"
 
       - name: Publish
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ steps.target.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -61,4 +100,4 @@ jobs:
           echo "::notice::rather than 403 so it does not disclose whether a package exists."
           echo "::notice::Mint a new automation token at npmjs.com/settings/~/tokens, then:"
           echo "::notice::  gh secret set NPM_TOKEN"
-          echo "::notice::and re-run this workflow."
+          echo "::notice::and re-run this workflow with the tag as input."

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@
 *.db-shm
 icon.svg
 test/
+scripts/

--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ DB_PATH=./test.db npm start
 node dist/web/index.js ./test.db --open
 
 npm test     # unit and integration, ~140 tests, no network
-npm run e2e  # packs a tarball, installs it, drives the real binaries
+npm run e2e  # release gate: packs a tarball, installs it, drives the real binaries
 ```
 
 ### Releasing

--- a/README.md
+++ b/README.md
@@ -530,7 +530,33 @@ DB_PATH=./test.db npm start
 
 # the web UI against the same database
 node dist/web/index.js ./test.db --open
+
+npm test     # unit and integration, ~140 tests, no network
+npm run e2e  # packs a tarball, installs it, drives the real binaries
 ```
+
+### Releasing
+
+Publishing to npm is irreversible — a version number can never be reused — so it is the *last*
+step, and it is triggered by publishing a GitHub release, not by pushing a tag.
+
+```bash
+# 1. bump the version in package.json, manifest.json and server.json, then merge
+# 2. tag it. Nothing is published yet.
+git tag -a v1.9.0 -m "v1.9.0 — ..." && git push origin v1.9.0
+
+# 3. verify the tagged build: this packs the tarball that would be published
+#    and drives it end to end, including an upgrade from an older database.
+npm run e2e
+
+# 4. publish the release. This fires the publish workflow.
+gh release create v1.9.0 --notes-file notes.md
+```
+
+The workflow re-runs the suite against the tagged commit, refuses a tag that does not match
+`package.json`, refuses a version already on npm, and sends a GitHub *pre-release* to the `next`
+dist-tag so it never becomes what `npm install saga-mcp` gives people. A failed publish can be
+retried against the same tag with `gh workflow run "Publish to npm" -f tag=v1.9.0`.
 
 ## Support
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
   "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 35 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saga-mcp",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saga-mcp",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.8.1",
-  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
+  "version": "1.8.2",
+  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard — so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -24,7 +24,8 @@
     "dev": "tsc && node dist/index.js",
     "prepublishOnly": "npm run build",
     "test": "npm run build && node --test",
-    "test:only": "node --test"
+    "test:only": "node --test",
+    "e2e": "npm run build && node test/e2e.mjs"
   },
   "keywords": [
     "mcp",
@@ -62,5 +63,9 @@
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.2",
     "typescript": "^5.7.2"
+  },
+  "types": "./dist/index.d.ts",
+  "directories": {
+    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
   "version": "1.8.2",
-  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard — so LLMs never lose track.",
+  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -25,7 +25,7 @@
     "prepublishOnly": "npm run build",
     "test": "npm run build && node --test",
     "test:only": "node --test",
-    "e2e": "npm run build && node test/e2e.mjs"
+    "e2e": "npm run build && node scripts/e2e.mjs"
   },
   "keywords": [
     "mcp",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -8,8 +8,10 @@
  * Run this on a tagged build BEFORE publishing the GitHub release, because
  * publishing the release is what pushes to npm, and npm is forever.
  *
- * Not part of `npm test`: it builds a tarball and installs it, which takes
- * about a minute and needs a working npm.
+ * Deliberately outside test/: `node --test` discovers **\/test\/**\/*.mjs, so
+ * living there meant `npm test` ran it — including in CI, where installing a
+ * fresh tarball rebuilds better-sqlite3 and needs a toolchain the Windows
+ * runners do not have. This is a release gate, not a unit test.
  */
 import { spawn, execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, rmSync, readdirSync } from 'node:fs';

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.8.1",
+  "version": "1.8.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -199,10 +199,32 @@ function start(opts: Options): void {
   const firstPort = opts.port ?? DEFAULT_PORT;
   const attempts = explicit ? 1 : PORT_SCAN_RANGE;
 
+  // Announce exactly once. server.listen(port, host, cb) registers cb as a
+  // 'listening' listener, so passing it on every retry accumulated one per
+  // attempted port — the banner printed once per attempt, and --open opened
+  // that many browser tabs.
+  const announce = (): void => {
+    const bound = server.address();
+    const actual = typeof bound === 'object' && bound ? bound.port : firstPort;
+    const shown = opts.host === '0.0.0.0' || opts.host === '::' ? 'localhost' : opts.host;
+    const url = `http://${shown}:${actual}`;
+    console.log(`saga-web  ${url}`);
+    console.log(`database  ${opts.dbPath}`);
+    console.log(`mode      ${opts.readOnly ? 'read-only' : 'editable'}`);
+    if (!explicit && actual !== firstPort) {
+      console.log(`note      ${firstPort} was busy — took the next free port.`);
+    }
+    if (opts.host !== '127.0.0.1' && opts.host !== 'localhost') {
+      console.log('warning   bound beyond localhost — this UI has no authentication.');
+    }
+    opts.port = actual;
+    if (opts.open) openBrowser(url);
+  };
+  server.once('listening', announce);
+
   const tryListen = (port: number, remaining: number): void => {
     const onError = (err: NodeJS.ErrnoException) => {
       if (err.code !== 'EADDRINUSE') throw err;
-      server.removeListener('error', onError);
       if (remaining <= 1) {
         console.error(
           explicit
@@ -214,24 +236,7 @@ function start(opts: Options): void {
       tryListen(port + 1, remaining - 1);
     };
     server.once('error', onError);
-    server.listen(port, opts.host, () => {
-      server.removeListener('error', onError);
-      const bound = server.address();
-      const actual = typeof bound === 'object' && bound ? bound.port : port;
-      const shown = opts.host === '0.0.0.0' || opts.host === '::' ? 'localhost' : opts.host;
-      const url = `http://${shown}:${actual}`;
-      console.log(`saga-web  ${url}`);
-      console.log(`database  ${opts.dbPath}`);
-      console.log(`mode      ${opts.readOnly ? 'read-only' : 'editable'}`);
-      if (!explicit && actual !== firstPort) {
-        console.log(`note      ${firstPort} was busy — took the next free port.`);
-      }
-      if (opts.host !== '127.0.0.1' && opts.host !== 'localhost') {
-        console.log('warning   bound beyond localhost — this UI has no authentication.');
-      }
-      opts.port = actual;
-      if (opts.open) openBrowser(url);
-    });
+    server.listen(port, opts.host);
   };
 
   tryListen(firstPort, attempts);

--- a/test/e2e.mjs
+++ b/test/e2e.mjs
@@ -1,0 +1,320 @@
+/**
+ * Release verification: pack the build, install that tarball into a clean
+ * directory, and drive it the way a user would — MCP over real stdio, and the
+ * web server over real HTTP. Nothing here imports the source.
+ *
+ *   npm run e2e
+ *
+ * Run this on a tagged build BEFORE publishing the GitHub release, because
+ * publishing the release is what pushes to npm, and npm is forever.
+ *
+ * Not part of `npm test`: it builds a tarball and installs it, which takes
+ * about a minute and needs a working npm.
+ */
+import { spawn, execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const work = mkdtempSync(join(tmpdir(), 'saga-e2e-'));
+const results = [];
+const ok = (n, c, x) => results.push((c ? 'PASS' : 'FAIL') + '  ' + n + (c || !x ? '' : '  -- ' + x));
+const section = (t) => results.push('\n--- ' + t + ' ---');
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const children = [];
+
+function cleanup() {
+  children.forEach((c) => { try { c.kill(); } catch { /* already gone */ } });
+  try { rmSync(work, { recursive: true, force: true }); } catch { /* windows file locks */ }
+}
+
+/* ---------------- install the real tarball ---------------- */
+
+section('packaging');
+execFileSync('npm', ['pack', '--pack-destination', work], { cwd: root, stdio: 'pipe', shell: true });
+const tarball = readdirSync(work).find((f) => f.endsWith('.tgz'));
+ok('npm pack produced a tarball', !!tarball, readdirSync(work).join(','));
+
+const app = join(work, 'app');
+mkdirSync(app, { recursive: true });
+execFileSync('npm', ['init', '-y'], { cwd: app, stdio: 'pipe', shell: true });
+execFileSync('npm', ['install', join(work, tarball)], { cwd: app, stdio: 'pipe', shell: true });
+
+const installed = join(app, 'node_modules', 'saga-mcp');
+const pkg = JSON.parse(execFileSync('node', ['-p', `JSON.stringify(require(${JSON.stringify(join(installed, 'package.json'))}))`], { encoding: 'utf8' }));
+ok('the tarball installs cleanly', !!pkg.version, pkg.version);
+ok('README ships', readdirSync(installed).includes('README.md'));
+ok('LICENSE ships', readdirSync(installed).includes('LICENSE'));
+ok('both binaries are declared', !!pkg.bin['saga-mcp'] && !!pkg.bin['saga-web']);
+
+const SERVER = join(installed, 'dist', 'index.js');
+const WEB = join(installed, 'dist', 'web', 'index.js');
+const DB = join(work, '.tracker.db');
+
+/* ---------------- MCP over stdio ---------------- */
+
+function mcp(env = {}) {
+  const child = spawn(process.execPath, [SERVER], {
+    env: { ...process.env, DB_PATH: DB, SAGA_TOOLS: '', SAGA_PROJECT: '', ...env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  children.push(child);
+  let stderr = '', buf = '';
+  const pending = new Map();
+  child.stderr.on('data', (d) => (stderr += d));
+  child.stdout.on('data', (c) => {
+    buf += c;
+    let i;
+    while ((i = buf.indexOf('\n')) >= 0) {
+      const line = buf.slice(0, i); buf = buf.slice(i + 1);
+      if (!line.trim()) continue;
+      const m = JSON.parse(line);
+      const r = pending.get(m.id);
+      if (r) { pending.delete(m.id); r(m); }
+    }
+  });
+  let id = 0;
+  const rpc = (method, params) => new Promise((res) => {
+    const my = ++id; pending.set(my, res);
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: my, method, params }) + '\n');
+  });
+  const ready = (async () => {
+    await rpc('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e', version: '1' } });
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+  })();
+  const call = async (name, args = {}) => {
+    const r = await rpc('tools/call', { name, arguments: args });
+    const text = r.result.content[0].text;
+    if (r.result.isError) return { __error: text };
+    try { return JSON.parse(text); } catch { return { __raw: text }; }
+  };
+  return { rpc, call, ready, stderr: () => stderr, stop: () => child.kill() };
+}
+
+const s = mcp();
+await s.ready;
+
+section('an agent plans a piece of work');
+const init = await s.call('tracker_init', { project_name: 'Checkout rewrite' });
+ok('tracker_init creates the first project', init.project?.name === 'Checkout rewrite');
+const projectId = init.project.id;
+
+const epic = await s.call('epic_create', { project_id: projectId, name: 'Provider swap', status: 'in_progress' });
+const t1 = await s.call('task_create', { epic_id: epic.id, title: 'Write the adapter', description: 'x'.repeat(400) });
+const t2 = await s.call('task_create', { epic_id: epic.id, title: 'Migrate cards', depends_on: [t1.id] });
+ok('a task with an unmet dependency is auto-blocked', (await s.call('task_get', { id: t2.id })).status === 'blocked');
+
+const subs = await s.call('subtask_create', { task_id: t1.id, titles: ['design', 'implement', 'test'] });
+ok('subtasks are numbered in order', JSON.stringify(subs.map((x) => x.sort_order)) === '[1,2,3]');
+const late = await s.call('subtask_create', { task_id: t1.id, titles: 'document' });
+ok('a later subtask appends rather than jumping to the front', late.sort_order === 4);
+
+section('a human reviews and reorders');
+const reordered = await s.call('subtask_reorder', { task_id: t1.id, ordered_ids: [subs[0].id, subs[1].id, late.id] });
+ok('reorder applies, unlisted items keep their order at the end',
+   reordered.map((x) => x.title).join(',') === 'design,implement,document,test', reordered.map((x) => x.title).join(','));
+await s.call('subtask_update', { id: subs[1].id, depends_on: [subs[0].id] });
+ok('a subtask reports itself blocked', (await s.call('task_get', { id: t1.id })).subtasks.find((x) => x.id === subs[1].id).blocked === true);
+
+section('blocked really means blocked');
+const refuse = await s.call('subtask_update', { id: subs[1].id, status: 'in_progress' });
+ok('starting a blocked subtask is refused', !!refuse.__error && /waits on/.test(refuse.__error), refuse.__error);
+ok('the refusal names the blocker', !!refuse.__error && refuse.__error.includes('#' + subs[0].id));
+ok('the status did not change', (await s.call('task_get', { id: t1.id })).subtasks.find((x) => x.id === subs[1].id).status === 'todo');
+const refuseDone = await s.call('subtask_update', { id: subs[1].id, status: 'done' });
+ok('completing a blocked subtask is refused too', !!refuseDone.__error);
+ok('force overrides', (await s.call('subtask_update', { id: subs[1].id, status: 'in_progress', force: true })).status === 'in_progress');
+ok('the override is logged', JSON.stringify(await s.call('activity_log', { entity_type: 'subtask', entity_id: subs[1].id, limit: 10 })).includes('forced past'));
+await s.call('subtask_update', { id: subs[1].id, status: 'todo' });
+
+const refuseTask = await s.call('task_update', { id: t1.id, status: 'done' });
+ok('a task will not complete over an open checklist', !!refuseTask.__error && /unfinished/.test(refuseTask.__error));
+ok('nor via a batch update', !!(await s.call('task_batch_update', { ids: [t1.id], status: 'done' })).__error);
+
+section('working through it in order');
+await s.call('subtask_update', { id: subs[0].id, status: 'done' });
+ok('the prerequisite being done lifts the block', (await s.call('subtask_update', { id: subs[1].id, status: 'in_progress' })).status === 'in_progress');
+for (const x of [subs[1].id, subs[2].id, late.id]) await s.call('subtask_update', { id: x, status: 'done' });
+ok('the task completes once the checklist is clear', (await s.call('task_update', { id: t1.id, status: 'done' })).status === 'done');
+ok('the downstream task auto-unblocks', (await s.call('task_get', { id: t2.id })).status !== 'blocked');
+
+section('guarding the spec, and the discussion');
+await s.call('task_lock_description', { id: t2.id });
+ok('a locked description is protected', !!(await s.call('task_update', { id: t2.id, description: 'rewrite' })).__error);
+ok('the rest of the task stays editable', (await s.call('task_update', { id: t2.id, priority: 'high' })).priority === 'high');
+await s.call('task_lock_description', { id: t2.id, locked: false });
+ok('unlocking restores editing', (await s.call('task_update', { id: t2.id, description: 'ok' })).description === 'ok');
+
+const bad = await s.call('comment_add', { task_id: t2.id, content: 'a wrong claim', author: 'agent' });
+await s.call('comment_add', { task_id: t2.id, content: 'a good one', author: 'human' });
+await s.call('comment_delete', { id: bad.id, reason: 'wrong', deleted_by: 'human' });
+ok('a removed comment is hidden', (await s.call('comment_list', { task_id: t2.id })).length === 1);
+ok('but retrievable with its reason', (await s.call('comment_list', { task_id: t2.id, include_deleted: true })).some((c) => c.delete_reason === 'wrong'));
+ok('export carries the removal for the audit trail', JSON.stringify(await s.call('tracker_export', { project_id: projectId })).includes('wrong'));
+
+section('reading it back');
+const listed = await s.call('task_list', { limit: 50 });
+ok('list rows carry no nulls or metadata', listed.every((r) => !('metadata' in r) && !Object.values(r).includes(null)));
+ok('long descriptions are previewed in lists', listed.some((r) => typeof r.description === 'string' && r.description.endsWith('…')));
+ok('task_get returns the full description', (await s.call('task_get', { id: t1.id })).description.length === 400);
+ok('the dashboard reports real progress', (await s.call('tracker_dashboard', { project_id: projectId })).stats.total_tasks === 2);
+
+section('one database, several projects');
+const p2 = await s.call('project_create', { name: 'Second project' });
+const e2 = await s.call('epic_create', { project_id: p2.id, name: 'Other' });
+await s.call('task_create', { epic_id: e2.id, title: 'unrelated' });
+ok('unscoped calls still span the file', (await s.call('task_list', { limit: 50 })).length === 3);
+ok('project_id scopes them', (await s.call('task_list', { project_id: projectId, limit: 50 })).length === 2);
+ok('an ambiguous dashboard says it guessed', !!(await s.call('tracker_dashboard', {})).other_projects);
+s.stop();
+
+const scoped = mcp({ SAGA_PROJECT: 'Second project' });
+await scoped.ready;
+ok('SAGA_PROJECT scopes by name', (await scoped.call('task_list', { limit: 50 })).length === 1);
+scoped.stop();
+
+const badScope = mcp({ SAGA_PROJECT: 'nope' });
+await badScope.ready;
+ok('a bad SAGA_PROJECT fails loudly', /not a project/.test((await badScope.call('task_list', {})).__error ?? ''));
+badScope.stop();
+
+section('tool surface');
+const full = mcp();
+await full.ready;
+const fullTools = (await full.rpc('tools/list', {})).result.tools;
+ok('every tool is listed by default', fullTools.length === 35, String(fullTools.length));
+ok('every tool carries safety annotations', fullTools.every((t) => typeof t.annotations?.readOnlyHint === 'boolean'));
+ok('the tool list stays inside its context budget', JSON.stringify(fullTools).length < 25000, String(JSON.stringify(fullTools).length));
+full.stop();
+
+const core = mcp({ SAGA_TOOLS: 'core' });
+await core.ready;
+const coreTools = (await core.rpc('tools/list', {})).result.tools;
+ok('the core surface is much smaller', coreTools.length === 12 && JSON.stringify(coreTools).length < JSON.stringify(fullTools).length * 0.6);
+ok('a tool left off the list still works', !(await core.call('template_list', {})).__error);
+core.stop();
+
+/* ---------------- upgrading someone's existing database ---------------- */
+
+section('upgrading an older database in place');
+const legacyPath = join(work, 'legacy.db');
+const legacy = new Database(legacyPath);
+legacy.exec(`
+  CREATE TABLE projects (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT,
+    status TEXT NOT NULL DEFAULT 'active', tags TEXT NOT NULL DEFAULT '[]', metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE epics (id INTEGER PRIMARY KEY AUTOINCREMENT, project_id INTEGER NOT NULL, name TEXT NOT NULL,
+    description TEXT, status TEXT NOT NULL DEFAULT 'planned', priority TEXT NOT NULL DEFAULT 'medium',
+    sort_order INTEGER NOT NULL DEFAULT 0, tags TEXT NOT NULL DEFAULT '[]', metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, epic_id INTEGER NOT NULL, title TEXT NOT NULL,
+    description TEXT, status TEXT NOT NULL DEFAULT 'todo', priority TEXT NOT NULL DEFAULT 'medium',
+    sort_order INTEGER NOT NULL DEFAULT 0, assigned_to TEXT, estimated_hours REAL, actual_hours REAL,
+    due_date TEXT, tags TEXT NOT NULL DEFAULT '[]', metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE subtasks (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, title TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'todo', sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')), updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+  CREATE TABLE comments (id INTEGER PRIMARY KEY AUTOINCREMENT, task_id INTEGER NOT NULL, author TEXT,
+    content TEXT NOT NULL, created_at TEXT NOT NULL DEFAULT (datetime('now')));
+  INSERT INTO projects (name) VALUES ('Legacy');
+  INSERT INTO epics (project_id, name) VALUES (1, 'Legacy epic');
+  INSERT INTO tasks (epic_id, title, description) VALUES (1, 'Legacy task', 'old spec');
+  INSERT INTO subtasks (task_id, title) VALUES (1, 'legacy A');
+  INSERT INTO subtasks (task_id, title) VALUES (1, 'legacy B');
+  INSERT INTO comments (task_id, content) VALUES (1, 'old comment');
+`);
+legacy.close();
+
+const upgraded = mcp({ DB_PATH: legacyPath });
+await upgraded.ready;
+const legacyTask = await upgraded.call('task_get', { id: 1 });
+ok('an older database opens without error', legacyTask.title === 'Legacy task');
+ok('its data is intact', legacyTask.subtasks.length === 2 && legacyTask.comments.length === 1);
+await upgraded.call('subtask_update', { id: legacyTask.subtasks[1].id, depends_on: [legacyTask.subtasks[0].id] });
+ok('new tables are created by the upgrade', !!(await upgraded.call('task_get', { id: 1 })).subtasks.find((x) => x.id === legacyTask.subtasks[1].id).depends_on);
+ok('new guards apply to migrated rows', /waits on/.test((await upgraded.call('subtask_update', { id: legacyTask.subtasks[1].id, status: 'done' })).__error ?? ''));
+await upgraded.call('task_lock_description', { id: 1 });
+ok('new columns work on migrated rows', !!(await upgraded.call('task_get', { id: 1 })).description_locked);
+upgraded.stop();
+
+/* ---------------- the web server ---------------- */
+
+function web(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [WEB, DB, ...args], {
+      env: { ...process.env, SAGA_WEB_PORT: '', PORT: '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    children.push(child);
+    let out = '';
+    const timer = setTimeout(() => reject(new Error('saga-web did not start: ' + out)), 20000);
+    const onData = (d) => {
+      out += d;
+      const m = out.match(/saga-web\s+(http:\/\/\S+)/);
+      if (m) { clearTimeout(timer); resolve({ child, base: m[1], output: () => out }); }
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', onData);
+    child.on('exit', (code) => { clearTimeout(timer); reject(new Error('saga-web exited ' + code + ': ' + out)); });
+  });
+}
+const post = (base, body, headers = {}) =>
+  fetch(base + '/api/action', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-saga-ui': '1', ...headers },
+    body: JSON.stringify(body),
+  });
+
+section('the web UI');
+const ui = await web([]);
+ok('saga-web starts and prints its URL', /^http:\/\/127\.0\.0\.1:\d+$/.test(ui.base), ui.base);
+const page = await fetch(ui.base + '/');
+ok('it serves the page', page.status === 200 && (await page.text()).includes('<title>Saga</title>'));
+const projects = await (await fetch(ui.base + '/api/projects')).json();
+ok('the project list is served', projects.projects.length === 2 && projects.read_only === false);
+ok('the overview is served', (await fetch(`${ui.base}/api/overview?project_id=${projectId}`)).status === 200);
+ok('a task detail is served', (await (await fetch(`${ui.base}/api/tasks/${t1.id}`)).json()).subtasks.length === 4);
+
+ok('a write without the UI header is refused', (await fetch(ui.base + '/api/action', {
+  method: 'POST', headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ tool: 'task_update', args: { id: t1.id, status: 'todo' } }) })).status === 403);
+ok('a cross-origin write is refused',
+   (await post(ui.base, { tool: 'task_update', args: { id: t1.id, status: 'todo' } }, { origin: 'https://evil.example' })).status === 403);
+ok('a non-whitelisted tool is refused', (await post(ui.base, { tool: 'tracker_import', args: {} })).status === 400);
+ok('a legitimate write succeeds', (await post(ui.base, { tool: 'task_update', args: { id: t2.id, priority: 'low' } })).status === 200);
+const guardRes = await post(ui.base, { tool: 'task_update', args: { id: t2.id, status: 'done' } });
+const guardBody = await guardRes.json();
+ok('the guards reach the web API too', guardRes.status === 200 || /unfinished|blocked/.test(guardBody.error ?? ''), JSON.stringify(guardBody).slice(0, 90));
+
+const ro = await web(['--read-only']);
+ok('--read-only reports itself', (await (await fetch(ro.base + '/api/projects')).json()).read_only === true);
+ok('--read-only still serves reads', (await fetch(`${ro.base}/api/overview?project_id=${projectId}`)).status === 200);
+ok('--read-only refuses every write', (await post(ro.base, { tool: 'task_update', args: { id: t1.id, status: 'todo' } })).status === 403);
+
+const second = await web([]);
+ok('a second instance takes its own port', new URL(second.base).port !== new URL(ui.base).port,
+   ui.base + ' vs ' + second.base);
+await wait(300); // the note is printed just after the URL line we resolved on
+ok('and says why it moved', second.output().includes('took the next free port'), second.output());
+ok('and announces itself exactly once', (second.output().match(/saga-web {2}http/g) || []).length === 1,
+   String((second.output().match(/saga-web {2}http/g) || []).length));
+ok('both actually serve', (await fetch(second.base + '/api/projects')).status === 200);
+
+const pinned = await web(['--port', '4471']);
+ok('an explicit --port is honoured', new URL(pinned.base).port === '4471');
+let refusedPort = false;
+try { await web(['--port', '4471']); } catch { refusedPort = true; }
+ok('a taken explicit port fails rather than drifting', refusedPort);
+
+/* ---------------- report ---------------- */
+
+console.log(results.join('\n'));
+const failed = results.filter((r) => r.startsWith('FAIL')).length;
+const passed = results.filter((r) => r.startsWith('PASS')).length;
+console.log('\n' + (failed ? `${failed} FAILURES out of ${failed + passed}` : `all ${passed} checks passed against saga-mcp@${pkg.version}`));
+cleanup();
+process.exit(failed ? 1 : 0);

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -203,6 +203,17 @@ test('a second instance takes the next free port instead of failing', async () =
   }
 });
 
+test('a server that scanned past busy ports still announces itself once', async () => {
+  // server.listen(port, host, cb) registers cb as a 'listening' listener, so
+  // passing it on each retry accumulated one per attempted port: the banner
+  // printed once per attempt and --open opened that many browser tabs.
+  const after = await startWeb();
+  await new Promise((r) => setTimeout(r, 400));
+  const banners = (after.output().match(/saga-web {2}http/g) || []).length;
+  assert.equal(banners, 1, `expected one startup banner, got ${banners}:
+${after.output()}`);
+});
+
 test('an explicit --port is honoured exactly', async () => {
   const pinned = await startWeb(['--port', '4457']);
   assert.equal(new URL(pinned.base).port, '4457');


### PR DESCRIPTION
> The npm publish should only happen after release is tagged

Done — and specifically, after the **release is published**, not just after the tag exists.

## The problem

`push: tags: v*` published to npm the moment a tag landed. That put the irreversible step first: the package was on the registry before anyone had looked at the tagged build. It's exactly how v1.8.1 shipped before its end-to-end run — the publish had already fired by the time you asked for the check.

## The flow now

```bash
git tag -a v1.9.0 -m "..." && git push origin v1.9.0   # publishes nothing
npm run e2e                                            # verify the real tarball
gh release create v1.9.0 --notes-file notes.md         # this publishes
```

Publishing the release is the deliberate act. Draft releases trigger nothing, so a draft can sit while verification runs.

Two more gates were cheap to add while I was in there, both of which would have made earlier confusion legible:

- **Refuse a version already on npm**, instead of letting npm answer with a 403 that reads like an auth failure.
- **A GitHub pre-release goes to the `next` dist-tag**, so it can never become what `npm install saga-mcp` gives people.

`workflow_dispatch` is kept for retrying a failed publish against an existing tag.

## `npm run e2e` — what makes the gate worth having

A gate you can't act on is theatre, so the verification step is now a committed script. It packs **the tarball that would actually be published**, installs it into a clean directory, and drives it as a user would — importing none of the source:

- MCP over real stdio: a whole project lifecycle, plan → review → work → complete
- every guard: blocked subtasks, unfinished checklists, batch bypass, `force` and its log entry
- the description lock, comment soft-delete, export carrying the audit trail
- multi-project scoping and `SAGA_PROJECT`, the tiered tool surface, the context budget
- an upgrade from a synthetic pre-1.8 database
- the web server over HTTP: CSRF guards, the write whitelist, read-only mode, port scanning

**66 checks**, run against `saga-mcp@1.8.1` before this PR.

## It found a real bug

`server.listen(port, host, cb)` registers `cb` as a `'listening'` listener, so passing it on every retry accumulated one per attempted port. A `saga-web` that scanned past two busy ports **printed its startup banner three times** — and `--open` would have opened three browser tabs.

Announcing is now registered once, outside the retry loop. Verified with three concurrent instances (one banner each after scanning past busy ports), with a regression test in `test/web.test.js`.

**142 tests** passing, plus the 66 E2E checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
