### PR TITLE
fix(web): stop form-field CSS stretching checkboxes across the row (#25)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
   "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 35 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saga-mcp",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saga-mcp",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.8.2",
+  "version": "1.8.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "transport": {
         "type": "stdio"
       },

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -200,7 +200,7 @@ body.resizing { cursor: ew-resize; user-select: none; }
 .modal h2 { margin: 0 0 14px; font-size: 16px; }
 .field { margin-bottom: 12px; }
 .field label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 4px; }
-.field input, .field select { width: 100%; }
+.field input:not([type=checkbox]), .field select { width: 100%; }
 .field.inline { display: flex; gap: 10px; }
 .field.inline > div { flex: 1; }
 .kv { display: grid; grid-template-columns: max-content 1fr; gap: 4px 14px; font-size: 13px; }
@@ -220,6 +220,8 @@ body.resizing { cursor: ew-resize; user-select: none; }
 .act time { color: var(--muted); font-size: 12px; white-space: nowrap; font-variant-numeric: tabular-nums; }
 .checklist { max-height: 220px; overflow-y: auto; border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; }
 .checkrow { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 13px; cursor: pointer; }
+.checkrow input[type=checkbox] { width: auto; flex: none; margin: 0; }
+.checkrow span { flex: 1; min-width: 0; }
 .sub .handle { cursor: grab; color: var(--muted); user-select: none; font-size: 12px; }
 /* One control per subtask carrying its whole state: todo / in progress / done,
    or blocked. Clicking advances it, so 'in progress' is reachable from the UI. */

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -14,6 +14,8 @@ import { PAGE } from '../dist/web/ui.js';
  */
 
 const script = PAGE.match(/<script>([\s\S]*?)<\/script>/)[1];
+const css = PAGE.match(/<style>([\s\S]*?)<\/style>/)[1]
+  .replace(/\/\*[\s\S]*?\*\//g, '');   // comments would leak into selectors
 
 function element() {
   const node = {
@@ -177,4 +179,90 @@ test('the task drawer offers a refresh control', () => {
 test('every write still goes through the guarded action endpoint', () => {
   assert.ok(script.includes("'/api/action'"));
   assert.ok(script.includes("'x-saga-ui': '1'"), 'the CSRF header must not be dropped');
+});
+
+/* ---------- CSS cascade ---------- */
+
+/** Every rule that declares `property`, in source order. */
+function declarationsOf(property) {
+  const out = [];
+  for (const [, rawSelector, body] of css.matchAll(/([^{}]+)\{([^}]*)\}/g)) {
+    // Split the declaration block by hand rather than building a regex from the
+    // property name — it keeps this readable and avoids escaping surprises.
+    let value = null;
+    for (const part of body.split(';')) {
+      const colon = part.indexOf(':');
+      if (colon < 0) continue;
+      if (part.slice(0, colon).trim() !== property) continue;
+      value = part.slice(colon + 1).trim();
+    }
+    if (value === null) continue;
+    for (const sel of rawSelector.split(',').map((x) => x.trim())) {
+      out.push({ sel, value });
+    }
+  }
+  return out;
+}
+
+/** Rough specificity: [ids, classes+attributes+pseudo-classes, element types]. */
+function specificity(sel) {
+  const ids = (sel.match(/#[\w-]+/g) || []).length;
+  const classes = (sel.match(/\.[\w-]+|\[[^\]]+\]|:[\w-]+/g) || []).length;
+  const types = (sel.match(/(^|[\s>+~])[a-z]+/gi) || []).length;
+  return [ids, classes, types];
+}
+
+/**
+ * Does this selector apply to an <input type=checkbox> sitting inside the given
+ * ancestor class? Deliberately narrow — it only understands the handful of
+ * shapes this stylesheet uses.
+ */
+function appliesToCheckbox(sel, ancestorClasses) {
+  if (sel.includes(':not([type=checkbox])')) return false;
+  const parts = sel.split(/\s+/);
+  const target = parts[parts.length - 1];
+  if (target !== 'input' && target !== 'input[type=checkbox]') return false;
+  const ancestors = parts.slice(0, -1);
+  return ancestors.every((a) => ancestorClasses.includes(a));
+}
+
+/** The declaration that actually wins: highest specificity, latest on a tie. */
+function winner(candidates) {
+  let best = null;
+  candidates.forEach((c, order) => {
+    const spec = specificity(c.sel);
+    if (!best) { best = { ...c, spec, order }; return; }
+    for (let i = 0; i < 3; i++) {
+      if (spec[i] !== best.spec[i]) { if (spec[i] > best.spec[i]) best = { ...c, spec, order }; return; }
+    }
+    best = { ...c, spec, order }; // equal specificity: later wins
+  });
+  return best;
+}
+
+test('a checkbox inside a form field keeps its natural width', () => {
+  // Reported on #25: the checkbox filled its row and pushed the label onto the
+  // next line. `.field input { width: 100% }` and `input[type=checkbox] { width: auto }`
+  // had identical specificity, so whichever came last silently won. Asserting
+  // the source order of two rules would be brittle, so resolve the cascade.
+  const widths = declarationsOf('width');
+  const applicable = widths.filter((d) => appliesToCheckbox(d.sel, ['.field', '.checkrow']));
+  assert.ok(applicable.length > 0, 'expected at least one width rule to reach a checkbox');
+  const won = winner(applicable);
+  assert.notEqual(won.value, '100%',
+    `a checkbox in a .field would be stretched by "${won.sel} { width: ${won.value} }"`);
+  assert.equal(won.value, 'auto');
+});
+
+test('the deps checklist row lays out on one line', () => {
+  assert.match(css, /\.checkrow \{[^}]*display: flex/);
+  assert.match(css, /\.checkrow input\[type=checkbox\][^}]*width: auto/);
+  assert.match(css, /\.checkrow input\[type=checkbox\][^}]*flex: none/);
+});
+
+test('ordinary text inputs in a field still fill the row', () => {
+  // The fix must not quietly regress every other form field.
+  const rule = declarationsOf('width').find((d) => d.sel === '.field input:not([type=checkbox])');
+  assert.ok(rule, 'the .field input width rule should still exist');
+  assert.equal(rule.value, '100%');
 });


### PR DESCRIPTION
Closes #25 — reported *and diagnosed* by @rusak47, who worked out the cause after I twice said I couldn't reproduce it.

> When disabled checkbox style "width 100%" - it renders normally.

That was the answer. Two rules with **identical specificity** (0,1,1):

```css
input[type=checkbox] { width: auto; }    /* line 84  */
.field input         { width: 100%; }    /* line 203 */
```

Equal specificity means source order decides, so the later rule won and every checkbox inside a form field stretched to fill its line, pushing the label onto the next one.

I'd looked at `.checkrow { display: flex }`, seen a correct single-line layout, and concluded the markup was fine — which it was. The layout was never the problem; a competing `width` was, and I never checked for one. Screenshots in two browsers plus the "disable this rule and it works" step is a complete bug report, and it went straight to the cause.

**Fixed at the source** rather than by layering a third override: `.field input` now excludes checkboxes, and `.checkrow` pins its own checkbox `width`/`flex` so a future width rule can't reach it either.

## The regression test resolves the cascade

Asserting the source order of two rules would break the moment anyone reorders the stylesheet, so `test/page.test.js` now:

1. collects every `width` declaration whose selector can reach a checkbox inside `.field` or `.checkrow`
2. ranks them by specificity, later-wins on ties — the actual cascade rule that caused this
3. asserts the winner isn't `100%`, and names the offending rule if it is

Verified by reintroducing the bug: **the test fails**, with `a checkbox in a .field would be stretched by ".field input { width: 100% }"`. A companion test checks ordinary text inputs still fill the row, so the fix can't quietly regress every other form.

**143 tests** passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
