### PR TITLE
feat: task ordering and dependency editing, plus three fixes found checking them (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ lived in the context window, or in a `TODO.md` nobody updates.
 
 saga-mcp gives the agent a real tracker instead: a SQLite file in your project
 holding projects, epics, tasks, subtasks, dependencies, comments, notes and
-decisions, exposed as 38 MCP tools. The agent writes to it as it works and
+decisions, exposed as 39 MCP tools. The agent writes to it as it works and
 reads the dashboard when it comes back. No accounts, no external service, no
 network calls — the database is a file you own.
 
@@ -76,7 +76,7 @@ recent activity, notes.
 - **Activity log**: Every mutation is automatically tracked with old/new values
 - **Notes system**: Decisions, context, meeting notes, blockers — all searchable
 - **Batch operations**: Create multiple subtasks or update multiple tasks in one call
-- **38 focused tools**: With MCP safety annotations on every tool
+- **39 focused tools**: With MCP safety annotations on every tool
 - **Import/export**: Full project backup and migration as JSON (with dependencies and comments)
 - **Source references**: Link tasks to specific code locations
 - **Auto time tracking**: Hours computed automatically from activity log
@@ -192,6 +192,7 @@ import/export, session diffs and the rest discoverable.
 | `task_get` | Get task with subtasks, notes, comments, and dependencies | `readOnly: true` |
 | `task_update` | Update task (auto-logs, auto-blocks/unblocks) | `readOnly: false`, `idempotent: true` |
 | `task_lock_description` | Lock/unlock a description so agents can't rewrite it | `readOnly: false`, `idempotent: true` |
+| `task_reorder` | Set the order of an epic's tasks | `readOnly: false`, `idempotent: true` |
 | `task_delete` | Remove a `todo` task (soft delete, restorable) | `readOnly: false`, `idempotent: true` |
 | `task_restore` | Restore a removed task | `readOnly: false`, `idempotent: true` |
 | `task_batch_update` | Update multiple tasks at once | `readOnly: false`, `idempotent: true` |
@@ -380,6 +381,31 @@ Coercion stops where intent becomes ambiguous. A comma inside a *title* is left 
 `"Design the API, then implement it"` is one subtask, not two — while a comma in a tag or an id
 list is a separator, because neither can contain one. Anything genuinely unusable is refused with
 a message naming what arrived and what was wanted, rather than a leaked `ids.map is not a function`.
+
+## Ordering and dependencies
+
+`task_list` sorts by priority by default, which is usually what an agent wants but ignores any
+order you arranged by hand. `sort_by: "manual"` reads back the order `task_reorder` set:
+
+```
+task_reorder({ epic_id: 2, ordered_ids: [8, 5, 6] })
+task_list({ epic_id: 2, sort_by: "manual" })     # 8, 5, 6
+```
+
+Anything omitted from `ordered_ids` keeps its relative position at the end. `sort_order` runs
+ascending — lower sorts first — and in the web UI you can drag tasks into place inside an epic.
+
+Task dependencies auto-block and auto-unblock:
+
+```
+task_update({ id: 9, depends_on: [8] })   # 9 becomes blocked while 8 is open
+```
+
+Re-evaluation runs whenever a blocker's *doneness* changes in either direction, so reopening a
+finished blocker blocks its dependents again, and clearing the last dependency releases them.
+Circular dependencies are refused with the loop named, for tasks and subtasks alike — anything
+in a cycle would be blocked forever. The web UI shows a banner at the top of a blocked task
+naming what it waits on, with a picker to add or remove dependencies.
 
 ## Getting old work out of the way
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
   "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 35 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saga-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saga-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -164,6 +164,33 @@ ok('long descriptions are previewed in lists', listed.some((r) => typeof r.descr
 ok('task_get returns the full description', (await s.call('task_get', { id: t1.id })).description.length === 400);
 ok('the dashboard reports real progress', (await s.call('tracker_dashboard', { project_id: projectId })).stats.total_tasks === 2);
 
+section('ordering and dependencies');
+{
+  const orderEpic = await s.call('epic_create', { project_id: projectId, name: 'Ordered work' });
+  const one = await s.call('task_create', { epic_id: orderEpic.id, title: 'step one', priority: 'low' });
+  const two = await s.call('task_create', { epic_id: orderEpic.id, title: 'step two', priority: 'critical' });
+  await s.call('task_reorder', { epic_id: orderEpic.id, ordered_ids: [one.id, two.id] });
+  const manual = await s.call('task_list', { epic_id: orderEpic.id, sort_by: 'manual', limit: 10 });
+  ok('task_reorder + sort_by manual round-trips', manual.map((t) => t.title).join(',') === 'step one,step two',
+     manual.map((t) => t.title).join(','));
+  const byPriority = await s.call('task_list', { epic_id: orderEpic.id, limit: 10 });
+  ok('the default sort is still priority', byPriority[0].title === 'step two');
+
+  await s.call('task_update', { id: two.id, depends_on: [one.id] });
+  ok('a dependent task auto-blocks', (await s.call('task_get', { id: two.id })).status === 'blocked');
+  await s.call('task_update', { id: one.id, status: 'done' });
+  ok('finishing the blocker releases it', (await s.call('task_get', { id: two.id })).status !== 'blocked');
+  await s.call('task_update', { id: one.id, status: 'todo' });
+  ok('reopening the blocker blocks it again', (await s.call('task_get', { id: two.id })).status === 'blocked');
+  await s.call('task_update', { id: two.id, depends_on: [] });
+  ok('clearing the dependency releases it', (await s.call('task_get', { id: two.id })).status !== 'blocked');
+
+  await s.call('task_update', { id: two.id, depends_on: [one.id] });
+  const cycle = await s.call('task_update', { id: one.id, depends_on: [two.id] });
+  ok('a circular task dependency is refused', /circular/.test(cycle.__error ?? ''), cycle.__error);
+  await s.call('task_update', { id: two.id, depends_on: [] });
+}
+
 section('getting old work out of the way');
 {
   const shelf = await s.call('epic_create', { project_id: projectId, name: 'Finished work', status: 'completed' });
@@ -214,7 +241,7 @@ section('tool surface');
 const full = mcp();
 await full.ready;
 const fullTools = (await full.rpc('tools/list', {})).result.tools;
-ok('every tool is listed by default', fullTools.length === 38, String(fullTools.length));
+ok('every tool is listed by default', fullTools.length === 39, String(fullTools.length));
 ok('every tool carries safety annotations', fullTools.every((t) => typeof t.annotations?.readOnlyHint === 'boolean'));
 ok('the tool list stays inside its context budget', JSON.stringify(fullTools).length < 28000, String(JSON.stringify(fullTools).length));
 ok('and tool descriptions have not crept', JSON.stringify(fullTools).length / fullTools.length < 750,

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.10.0",
+  "version": "1.11.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/helpers/dependency-graph.ts
+++ b/src/helpers/dependency-graph.ts
@@ -1,0 +1,80 @@
+import type Database from 'better-sqlite3';
+
+/**
+ * Cycle detection, shared by task and subtask dependencies.
+ *
+ * Subtasks refused cycles from the start (#22). Tasks never did — `A depends
+ * on B, B depends on A` was accepted, and the auto-blocking then put both in
+ * `blocked` permanently, where nothing could ever release them. The two
+ * dependency graphs are the same shape, so they should refuse the same things.
+ *
+ * This matters more now that dependencies are editable from the web UI: it is
+ * a click away rather than a deliberate pair of tool calls.
+ */
+export interface DependencyEdge {
+  from: number;
+  to: number;
+}
+
+/**
+ * Throw if pointing `id` at `dependsOn` would close a loop.
+ *
+ * `edges` is the existing graph; edges starting at `id` are ignored, since the
+ * caller is about to replace them.
+ */
+export function assertAcyclic(
+  edges: DependencyEdge[],
+  id: number,
+  dependsOn: number[],
+  label: string
+): void {
+  const graph = new Map<number, number[]>();
+  for (const edge of edges) {
+    if (edge.from === id) continue; // replaced by dependsOn below
+    graph.set(edge.from, [...(graph.get(edge.from) ?? []), edge.to]);
+  }
+  graph.set(id, dependsOn);
+
+  const seen = new Set<number>();
+  const stack = new Set<number>();
+  const walk = (node: number): number[] | null => {
+    if (stack.has(node)) return [node];
+    if (seen.has(node)) return null;
+    seen.add(node);
+    stack.add(node);
+    for (const next of graph.get(node) ?? []) {
+      const cycle = walk(next);
+      if (cycle) return [node, ...cycle];
+    }
+    stack.delete(node);
+    return null;
+  };
+
+  const cycle = walk(id);
+  if (cycle) {
+    throw new Error(
+      `That would make a circular ${label} dependency: ${cycle.map((n) => `#${n}`).join(' → ')}. ` +
+        'Nothing in a cycle can ever start.'
+    );
+  }
+}
+
+/** Every task dependency edge, for the check above. */
+export function taskEdges(db: Database.Database): DependencyEdge[] {
+  return (
+    db.prepare('SELECT task_id, depends_on_task_id FROM task_dependencies').all() as Array<{
+      task_id: number;
+      depends_on_task_id: number;
+    }>
+  ).map((row) => ({ from: row.task_id, to: row.depends_on_task_id }));
+}
+
+/** Every subtask dependency edge. */
+export function subtaskEdges(db: Database.Database): DependencyEdge[] {
+  return (
+    db.prepare('SELECT subtask_id, depends_on_subtask_id FROM subtask_dependencies').all() as Array<{
+      subtask_id: number;
+      depends_on_subtask_id: number;
+    }>
+  ).map((row) => ({ from: row.subtask_id, to: row.depends_on_subtask_id }));
+}

--- a/src/tools/subtasks.ts
+++ b/src/tools/subtasks.ts
@@ -4,6 +4,7 @@ import { getDb } from '../db.js';
 import { logActivity } from '../helpers/activity-logger.js';
 import { guardSubtaskStatus, FORCE_SCHEMA } from '../helpers/completion-guard.js';
 import { asTitleList, asIdList } from '../helpers/coerce.js';
+import { assertAcyclic, subtaskEdges } from '../helpers/dependency-graph.js';
 import type { ToolHandler } from '../types.js';
 
 export const definitions: Tool[] = [
@@ -131,48 +132,11 @@ function assertSameTask(db: Database.Database, taskId: number, ids: number[]): v
   }
 }
 
-/** Walk the dependency graph to keep it acyclic; a cycle would block every member forever. */
-function assertNoCycle(db: Database.Database, subtaskId: number, dependsOn: number[]): void {
-  const edges = db.prepare('SELECT subtask_id, depends_on_subtask_id FROM subtask_dependencies').all() as Array<{
-    subtask_id: number;
-    depends_on_subtask_id: number;
-  }>;
-
-  const graph = new Map<number, number[]>();
-  for (const e of edges) {
-    if (e.subtask_id === subtaskId) continue; // replaced below
-    graph.set(e.subtask_id, [...(graph.get(e.subtask_id) ?? []), e.depends_on_subtask_id]);
-  }
-  graph.set(subtaskId, dependsOn);
-
-  const seen = new Set<number>();
-  const stack = new Set<number>();
-  const walk = (node: number): number[] | null => {
-    if (stack.has(node)) return [node];
-    if (seen.has(node)) return null;
-    seen.add(node);
-    stack.add(node);
-    for (const next of graph.get(node) ?? []) {
-      const cycle = walk(next);
-      if (cycle) return [node, ...cycle];
-    }
-    stack.delete(node);
-    return null;
-  };
-
-  const cycle = walk(subtaskId);
-  if (cycle) {
-    throw new Error(
-      `That would make a circular dependency: ${cycle.map((id) => `#${id}`).join(' → ')}. ` +
-        'Nothing in a cycle can ever start.'
-    );
-  }
-}
 
 function setDependencies(db: Database.Database, subtaskId: number, taskId: number, dependsOn: number[]): void {
   const clean = [...new Set(dependsOn)].filter((id) => id !== subtaskId);
   assertSameTask(db, taskId, clean);
-  assertNoCycle(db, subtaskId, clean);
+  assertAcyclic(subtaskEdges(db), subtaskId, clean, 'subtask');
 
   db.prepare('DELETE FROM subtask_dependencies WHERE subtask_id = ?').run(subtaskId);
   const insert = db.prepare(

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -3,13 +3,14 @@ import type Database from 'better-sqlite3';
 import { getDb } from '../db.js';
 import { buildUpdate, addTagFilter } from '../helpers/sql-builder.js';
 import { logActivity, logEntityUpdate } from '../helpers/activity-logger.js';
-import { slimListRow, LIST_DESCRIPTION_CHARS } from '../helpers/slim.js';
+import { slimListRow, slimList, LIST_DESCRIPTION_CHARS } from '../helpers/slim.js';
 import { resolveProjectId, taskScopeClause, PROJECT_ID_SCHEMA } from '../helpers/project-scope.js';
 import { resolveBranch } from '../helpers/git.js';
 import { withDependencies } from './subtasks.js';
 import { guardTaskDone, FORCE_SCHEMA } from '../helpers/completion-guard.js';
 import { asIdList, tagsColumn } from '../helpers/coerce.js';
 import { liveTaskClause, wantsHidden, INCLUDE_ARCHIVED_SCHEMA, INCLUDE_DELETED_TASKS_SCHEMA } from '../helpers/visibility.js';
+import { assertAcyclic, taskEdges } from '../helpers/dependency-graph.js';
 import type { ToolHandler } from '../types.js';
 
 export const definitions: Tool[] = [
@@ -78,12 +79,26 @@ export const definitions: Tool[] = [
         include_deleted: INCLUDE_DELETED_TASKS_SCHEMA,
         sort_by: {
           type: 'string',
-          enum: ['priority', 'created', 'due_date', 'status'],
+          enum: ['priority', 'created', 'due_date', 'status', 'manual'],
           default: 'priority',
-          description: 'Sort order: priority (critical first), created (newest first), due_date (earliest first), status (actionable first)',
+          description: 'priority (critical first), created (newest first), due_date (earliest first), status (actionable first), manual (the order set by task_reorder)',
         },
         limit: { type: 'integer', default: 50, description: 'Max results' },
       },
+    },
+  },
+  {
+    name: 'task_reorder',
+    description:
+      "Set the order of an epic's tasks. Pass task IDs in the order you want; any omitted keep their relative order at the end. Read the result back with task_list sort_by=\"manual\" — the default sort is by priority, which ignores this.",
+    annotations: { title: 'Reorder Tasks', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        epic_id: { type: 'integer', description: 'Parent epic' },
+        ordered_ids: { type: 'array', items: { type: 'integer' }, description: 'Task IDs, in order' },
+      },
+      required: ['epic_id', 'ordered_ids'],
     },
   },
   {
@@ -167,7 +182,7 @@ export const definitions: Tool[] = [
           required: ['file'],
         },
         depends_on: { type: 'array', items: { type: 'integer' }, description: 'Task IDs this task depends on (replaces existing)' },
-        sort_order: { type: 'integer' },
+        sort_order: { type: 'integer', description: 'Manual position within the epic; lower sorts first. Use task_reorder instead of setting this by hand.' },
         tags: { type: 'array', items: { type: 'string' } },
         force: FORCE_SCHEMA,
       },
@@ -179,12 +194,14 @@ export const definitions: Tool[] = [
 // --- Dependency helpers ---
 
 function setDependencies(db: Database.Database, taskId: number, dependsOn: number[]): void {
+  const clean = [...new Set(dependsOn)].filter((depId) => depId !== taskId);
+  // A cycle here is worse than a bad edge: auto-blocking would put every task
+  // in the loop into `blocked` with nothing able to release them.
+  assertAcyclic(taskEdges(db), taskId, clean, 'task');
+
   db.prepare('DELETE FROM task_dependencies WHERE task_id = ?').run(taskId);
   const insert = db.prepare('INSERT INTO task_dependencies (task_id, depends_on_task_id) VALUES (?, ?)');
-  for (const depId of dependsOn) {
-    if (depId === taskId) continue; // prevent self-dependency
-    insert.run(taskId, depId);
-  }
+  for (const depId of clean) insert.run(taskId, depId);
 }
 
 function getUnmetDependencies(db: Database.Database, taskId: number): Array<{ id: number; title: string; status: string }> {
@@ -195,12 +212,24 @@ function getUnmetDependencies(db: Database.Database, taskId: number): Array<{ id
   ).all(taskId) as Array<{ id: number; title: string; status: string }>;
 }
 
-function evaluateAndUpdateDependencies(db: Database.Database, taskId: number): void {
+/**
+ * `dependenciesChanged` marks the case where this task's own dependency list
+ * was just edited. It matters when the list is now empty: a task holding no
+ * dependencies at all is normally left alone, because `blocked` is also a
+ * status a person can set by hand and clearing it silently would be wrong.
+ * But clearing the last dependency off a task the system had auto-blocked used
+ * to strand it in `blocked` with nothing left that could ever release it.
+ */
+function evaluateAndUpdateDependencies(
+  db: Database.Database,
+  taskId: number,
+  dependenciesChanged = false
+): void {
   const task = db.prepare('SELECT id, status, title FROM tasks WHERE id = ?').get(taskId) as { id: number; status: string; title: string } | undefined;
   if (!task) return;
 
   const deps = db.prepare('SELECT depends_on_task_id FROM task_dependencies WHERE task_id = ?').all(taskId) as Array<{ depends_on_task_id: number }>;
-  if (deps.length === 0) return;
+  if (deps.length === 0 && !dependenciesChanged) return;
 
   const unmet = getUnmetDependencies(db, taskId);
 
@@ -275,6 +304,10 @@ function getTaskOrderClause(sortBy: string): string {
       return `t.due_date IS NULL, t.due_date ASC, ${PRIORITY_ORDER}, t.created_at`;
     case 'created':
       return `t.created_at DESC`;
+    case 'manual':
+      // The order a human or agent actually arranged, which every other mode
+      // treats as a tiebreaker at best.
+      return `t.sort_order, t.created_at`;
     default:
       return `${PRIORITY_ORDER}, ${STATUS_ORDER}, t.sort_order, t.created_at`;
   }
@@ -461,7 +494,7 @@ function handleTaskUpdate(args: Record<string, unknown>) {
     logActivity(db, 'task', id, 'updated', 'depends_on', null,
       dependsOn.length > 0 ? dependsOn.join(',') : '(none)',
       `Task '${newRow.title}' dependencies updated: [${dependsOn.join(', ')}]`);
-    evaluateAndUpdateDependencies(db, id);
+    evaluateAndUpdateDependencies(db, id, true);
     // Re-fetch in case status changed
     newRow = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as Record<string, unknown>;
   }
@@ -489,8 +522,14 @@ function handleTaskUpdate(args: Record<string, unknown>) {
     }
   }
 
-  // Re-evaluate downstream tasks when this task is marked done
-  if (statusChanged && args.status === 'done') {
+  // Re-evaluate dependents whenever this task's *doneness* changes, in either
+  // direction. Only running this on the way into done meant reopening a
+  // finished blocker left everything waiting on it sitting in todo with an
+  // unmet dependency — the same class of hole as a dependency that never
+  // blocked at all.
+  const wasDone = oldRow.status === 'done';
+  const isDone = (newRow.status as string) === 'done';
+  if (wasDone !== isDone) {
     reevaluateDownstream(db, id);
   }
 
@@ -525,6 +564,40 @@ function handleTaskLockDescription(args: Record<string, unknown>) {
       : `Task ${id}'s description is unlocked.`,
     task: row,
   };
+}
+
+function handleTaskReorder(args: Record<string, unknown>) {
+  const db = getDb();
+  const epicId = args.epic_id as number;
+  const orderedIds = asIdList(args.ordered_ids ?? [], 'ordered_ids');
+
+  const siblings = db
+    .prepare('SELECT id FROM tasks WHERE epic_id = ? AND is_deleted = 0 ORDER BY sort_order, created_at')
+    .all(epicId) as Array<{ id: number }>;
+  if (siblings.length === 0) throw new Error(`Epic ${epicId} has no tasks`);
+
+  const known = new Set(siblings.map((row) => row.id));
+  const unknown = orderedIds.filter((taskId) => !known.has(taskId));
+  if (unknown.length > 0) {
+    throw new Error(`Task(s) ${unknown.join(', ')} do not belong to epic ${epicId}`);
+  }
+
+  // Anything left out keeps its relative order, after the listed ones.
+  const seen = new Set(orderedIds);
+  const finalOrder = [...orderedIds, ...siblings.map((row) => row.id).filter((rowId) => !seen.has(rowId))];
+
+  const stmt = db.prepare("UPDATE tasks SET sort_order = ?, updated_at = datetime('now') WHERE id = ?");
+  db.transaction(() => {
+    finalOrder.forEach((taskId, index) => stmt.run(index + 1, taskId));
+  })();
+
+  logActivity(db, 'epic', epicId, 'updated', 'sort_order', null, finalOrder.join(','),
+    `Tasks of epic ${epicId} reordered`);
+
+  return slimList(
+    db.prepare('SELECT * FROM tasks WHERE epic_id = ? AND is_deleted = 0 ORDER BY sort_order, created_at')
+      .all(epicId) as Array<Record<string, unknown>>
+  );
 }
 
 function handleTaskDelete(args: Record<string, unknown>) {
@@ -598,6 +671,7 @@ function handleTaskRestore(args: Record<string, unknown>) {
 
 export const handlers: Record<string, ToolHandler> = {
   task_create: handleTaskCreate,
+  task_reorder: handleTaskReorder,
   task_delete: handleTaskDelete,
   task_restore: handleTaskRestore,
   task_lock_description: handleTaskLockDescription,

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -36,6 +36,7 @@ const WRITE_TOOLS: Record<string, (args: Record<string, unknown>) => unknown> = 
   task_create: taskHandlers.task_create,
   task_update: taskHandlers.task_update,
   task_lock_description: taskHandlers.task_lock_description,
+  task_reorder: taskHandlers.task_reorder,
   task_delete: taskHandlers.task_delete,
   task_restore: taskHandlers.task_restore,
   subtask_create: subtaskHandlers.subtask_create,

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -250,6 +250,14 @@ body.resizing { cursor: ew-resize; user-select: none; }
   border: 1px solid var(--border); border-radius: 999px; padding: 0 6px;
 }
 .dep.unmet { color: var(--blocked); border-color: var(--blocked); }
+.blockedbanner {
+  display: flex; align-items: center; gap: 8px; margin: 10px 0 4px;
+  padding: 8px 10px; border-radius: 8px; font-size: 13px;
+  border: 1px solid var(--blocked); color: var(--blocked); background: var(--panel-2);
+}
+.tline.dragging { opacity: .4; }
+.tline.dropinto { border-top: 2px solid var(--accent); }
+.tline .thandle { cursor: grab; color: var(--muted); font-size: 12px; user-select: none; }
 .lockbtn.on { color: var(--high); border-color: var(--high); }
 .card.archived { opacity: .62; border-style: dashed; }
 .tline.removed .ellip { text-decoration: line-through; color: var(--muted); }
@@ -619,8 +627,11 @@ function tile(n, l) {
   return '<div class="tile"><div class="n">' + n + '</div><div class="l">' + l + '</div></div>';
 }
 
-function taskLine(t, extra) {
-  return '<div class="tline" data-task="' + t.id + '">' +
+function taskLine(t, extra, opts) {
+  var drag = opts && opts.draggable && canEdit();
+  return '<div class="tline" data-task="' + t.id + '"' +
+    (drag ? ' data-task-row="' + t.id + '" data-epic="' + t.epic_id + '" draggable="true"' : '') + '>' +
+    (drag ? '<span class="thandle" title="Drag to reorder">⠿</span>' : '') +
     '<span class="dot st-' + esc(t.status) + '"></span>' +
     '<span class="grow ellip">' + esc(t.title) + '</span>' +
     (extra ? '<span class="muted" style="font-size:12px">' + extra + '</span>' : '') +
@@ -698,7 +709,7 @@ function viewEpics() {
           var copy = {};
           for (var k in t) copy[k] = t[k];
           copy.epic_name = '';
-          return taskLine(copy, extra);
+          return taskLine(copy, extra, { draggable: true });
         }).join('') : '<div class="empty">No tasks in this epic.</div>') +
         '</div></div>';
     }
@@ -842,6 +853,13 @@ function drawTask() {
     (ed ? '<button class="btn" id="editTask">Edit task</button>' : '') +
     '<button class="btn" id="closeDrawer">Close ✕</button></div>';
   h += '<h2 style="margin:6px 0 8px;font-size:18px">' + esc(t.title) + '</h2>';
+  var unmetDeps = (t.depends_on || []).filter(function (d) { return d.status !== 'done'; });
+  if (unmetDeps.length) {
+    h += '<div class="blockedbanner">⛔ <span class="grow">Blocked by ' +
+      unmetDeps.map(function (d) {
+        return '<a href="#" data-task="' + d.id + '">#' + d.id + ' ' + esc(d.title) + '</a>';
+      }).join(', ') + '</span></div>';
+  }
   if (t.is_deleted) {
     h += '<div class="empty" style="color:var(--blocked)">This task was removed' +
       (t.deleted_by ? ' by ' + esc(t.deleted_by) : '') +
@@ -927,17 +945,22 @@ function drawTask() {
       '<button class="btn" id="addSubtask">Add</button></div>';
   }
 
-  if (t.depends_on.length || t.dependents.length) {
-    h += '<h3>Dependencies</h3>';
-    t.depends_on.forEach(function (x) {
-      h += '<div class="sub"><span class="muted">blocked by</span><span class="dot st-' + esc(x.status) +
-           '"></span><a href="#" data-task="' + x.id + '">' + esc(x.title) + '</a></div>';
-    });
-    t.dependents.forEach(function (x) {
-      h += '<div class="sub"><span class="muted">blocks</span><span class="dot st-' + esc(x.status) +
-           '"></span><a href="#" data-task="' + x.id + '">' + esc(x.title) + '</a></div>';
-    });
+  h += '<h3>Dependencies' +
+    (ed ? ' <button class="btn" id="editTaskDeps" title="Choose what this task waits on">⛓ Edit</button>' : '') +
+    '</h3>';
+  if (!t.depends_on.length && !t.dependents.length) {
+    h += '<div class="empty">None.</div>';
   }
+  t.depends_on.forEach(function (x) {
+    h += '<div class="sub"><span class="muted">waits on</span><span class="dot st-' + esc(x.status) +
+         '"></span><a href="#" class="grow ellip" data-task="' + x.id + '">#' + x.id + ' ' + esc(x.title) + '</a>' +
+         (ed ? '<button class="iconbtn danger" data-drop-dep="' + x.id + '" title="Remove this dependency">✕</button>' : '') +
+         '</div>';
+  });
+  t.dependents.forEach(function (x) {
+    h += '<div class="sub"><span class="muted">blocks</span><span class="dot st-' + esc(x.status) +
+         '"></span><a href="#" class="grow ellip" data-task="' + x.id + '">#' + x.id + ' ' + esc(x.title) + '</a></div>';
+  });
 
   var liveComments = t.comments.filter(function (c) { return !c.is_deleted; }).length;
   h += '<h3>Comments <span class="muted">(' + liveComments + ')</span></h3>';
@@ -1216,6 +1239,37 @@ document.addEventListener('click', function (ev) {
     return act('subtask_update', args).then(function () { return refresh(); }).catch(oops);
   }
 
+  if (target.id === 'editTaskDeps') {
+    var self = S.task;
+    var current = (self.depends_on || []).map(function (d) { return d.id; });
+    // Task dependencies are project-wide, so offer every other task, labelled
+    // with its epic. Finished ones are omitted unless already selected —
+    // a done task cannot block anything.
+    var candidates = S.tasks.filter(function (x) {
+      if (x.id === self.id) return false;
+      return x.status !== 'done' || current.indexOf(x.id) >= 0;
+    }).map(function (x) {
+      return { value: x.id, text: '#' + x.id + '  ' + x.title + '  · ' + (x.epic_name || '') +
+        (x.status === 'done' ? '  (done)' : '') };
+    });
+    return modal('“' + self.title + '” waits on…', [
+      { key: 'depends_on', label: 'Tasks that must finish first — this one is blocked until they are done',
+        type: 'checkboxes', options: candidates, value: current }
+    ], 'Save', function (values) {
+      return act('task_update', { id: self.id, depends_on: values.depends_on })
+        .then(function () { toast('Dependencies updated'); return refresh(); });
+    });
+  }
+
+  var dropDep = target.closest('[data-drop-dep]');
+  if (dropDep) {
+    var drop = Number(dropDep.dataset.dropDep);
+    var kept = (S.task.depends_on || []).map(function (d) { return d.id; })
+      .filter(function (x) { return x !== drop; });
+    return act('task_update', { id: S.task.id, depends_on: kept })
+      .then(function () { toast('Dependency removed'); return refresh(); }).catch(oops);
+  }
+
   var depsBtn = target.closest('[data-subtask-deps]');
   if (depsBtn) {
     var sid = Number(depsBtn.dataset.subtaskDeps);
@@ -1416,6 +1470,56 @@ document.addEventListener('mouseup', function () {
   if (drawer) {
     try { localStorage.setItem('saga.drawerWidth', drawer.style.width); } catch (e) { /* private mode */ }
   }
+});
+
+/* drag a task onto another to reorder within its epic */
+var dragTask = null;
+document.addEventListener('dragstart', function (ev) {
+  var row = ev.target.closest ? ev.target.closest('.tline[data-task-row]') : null;
+  if (!row) return;
+  dragTask = { id: Number(row.dataset.taskRow), epic: Number(row.dataset.epic) };
+  row.classList.add('dragging');
+  ev.dataTransfer.effectAllowed = 'move';
+  ev.dataTransfer.setData('text/plain', String(dragTask.id));
+  ev.stopPropagation();
+});
+document.addEventListener('dragover', function (ev) {
+  if (!dragTask) return;
+  var row = ev.target.closest ? ev.target.closest('.tline[data-task-row]') : null;
+  if (!row || Number(row.dataset.epic) !== dragTask.epic) return;
+  ev.preventDefault();
+  row.classList.add('dropinto');
+});
+document.addEventListener('dragleave', function (ev) {
+  var row = ev.target.closest ? ev.target.closest('.tline[data-task-row]') : null;
+  if (row) row.classList.remove('dropinto');
+});
+document.addEventListener('drop', function (ev) {
+  if (!dragTask) return;
+  var row = ev.target.closest ? ev.target.closest('.tline[data-task-row]') : null;
+  if (!row) return;
+  var targetEpic = Number(row.dataset.epic);
+  if (targetEpic !== dragTask.epic) { dragTask = null; return; }  // reordering is within one epic
+  ev.preventDefault();
+  ev.stopPropagation();
+  row.classList.remove('dropinto');
+  var target = Number(row.dataset.taskRow);
+  var moved = dragTask.id;
+  var epicId = dragTask.epic;
+  dragTask = null;
+  if (moved === target) return;
+
+  var order = S.tasks.filter(function (t) { return t.epic_id === epicId; }).map(function (t) { return t.id; });
+  order.splice(order.indexOf(moved), 1);
+  order.splice(order.indexOf(target), 0, moved);
+  act('task_reorder', { epic_id: epicId, ordered_ids: order })
+    .then(function () { toast('Reordered'); return refresh(); }).catch(oops);
+});
+document.addEventListener('dragend', function () {
+  dragTask = null;
+  Array.prototype.forEach.call(document.querySelectorAll('.tline.dragging, .tline.dropinto'), function (n) {
+    n.classList.remove('dragging'); n.classList.remove('dropinto');
+  });
 });
 
 /* drag a subtask onto another to reorder the checklist */

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -64,7 +64,7 @@ after(() => servers.forEach((s) => s.stop()));
 test('tools/list returns every tool by default', async () => {
   const s = await server();
   const res = await s.send('tools/list', {});
-  assert.equal(res.result.tools.length, 38);
+  assert.equal(res.result.tools.length, 39);
 });
 
 test('SAGA_TOOLS=core lists only the core surface, and it is much smaller', async () => {
@@ -93,7 +93,7 @@ test('a tool left off the core list is still callable by name', async () => {
 test('an unrecognised SAGA_TOOLS value warns and falls back to the full list', async () => {
   const s = await server({ SAGA_TOOLS: 'nonsense' });
   const res = await s.send('tools/list', {});
-  assert.equal(res.result.tools.length, 38);
+  assert.equal(res.result.tools.length, 39);
   assert.match(s.stderr(), /Unknown SAGA_TOOLS/);
 });
 

--- a/test/task-order-deps.test.js
+++ b/test/task-order-deps.test.js
@@ -1,0 +1,178 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDbPath, loadTools } from './helpers.js';
+
+/**
+ * #37. Two reports, and re-checking them turned up a third problem nobody had
+ * noticed.
+ *
+ *  1. An agent numbering tasks 1,2,3 got them back in a different order. The
+ *     cause was not a missing reorder tool: task_list defaults to sort_by
+ *     'priority', where sort_order is only a third-level tiebreaker, and there
+ *     was no way to sort by it at all.
+ *  2. Task dependencies could be set but not seen or edited in the UI.
+ *  3. Found while checking 2: reopening a *completed* blocker left everything
+ *     waiting on it unblocked — reevaluateDownstream only ran on the way INTO
+ *     done, never on the way out.
+ */
+const t = await loadTools(tempDbPath('saga-order'));
+const project = t.project_create({ name: 'P' });
+const epic = t.epic_create({ project_id: project.id, name: 'E' });
+const other = t.epic_create({ project_id: project.id, name: 'Other' });
+
+const titles = (rows) => rows.map((r) => r.title);
+
+/* ---------- ordering ---------- */
+
+const a = t.task_create({ epic_id: epic.id, title: 'Phase 1.1', priority: 'medium' });
+const b = t.task_create({ epic_id: epic.id, title: 'Phase 1.2', priority: 'critical' });
+const c = t.task_create({ epic_id: epic.id, title: 'Phase 2', priority: 'low' });
+
+test('the default sort is still priority — unchanged for existing callers', () => {
+  assert.deepEqual(titles(t.task_list({ epic_id: epic.id, limit: 10 })),
+                   ['Phase 1.2', 'Phase 1.1', 'Phase 2']);
+});
+
+test('task_reorder sets the order, and sort_by manual reads it back', () => {
+  // The reported symptom: numbering them 1,2,3 and getting a different order.
+  t.task_reorder({ epic_id: epic.id, ordered_ids: [a.id, b.id, c.id] });
+  assert.deepEqual(titles(t.task_list({ epic_id: epic.id, sort_by: 'manual', limit: 10 })),
+                   ['Phase 1.1', 'Phase 1.2', 'Phase 2']);
+});
+
+test('manual order is ascending — lower sorts first', () => {
+  const rows = t.task_list({ epic_id: epic.id, sort_by: 'manual', limit: 10 });
+  const orders = rows.map((r) => r.sort_order);
+  assert.deepEqual(orders, [...orders].sort((x, y) => x - y));
+});
+
+test('sort_order now documents which way it runs', async () => {
+  // With no description at all, an agent guessing the convention had even odds
+  // of getting it backwards — which is what was reported.
+  const { loadDefinitions } = await import('./helpers.js');
+  const def = (await loadDefinitions()).find((d) => d.name === 'task_update');
+  const desc = def.inputSchema.properties.sort_order.description ?? '';
+  assert.match(desc, /lower sorts first/);
+  const list = (await loadDefinitions()).find((d) => d.name === 'task_list');
+  assert.ok(list.inputSchema.properties.sort_by.enum.includes('manual'),
+    'manual must be a reachable sort mode');
+});
+
+test('tasks left out of a reorder keep their relative order, at the end', () => {
+  t.task_reorder({ epic_id: epic.id, ordered_ids: [c.id] });
+  assert.deepEqual(titles(t.task_list({ epic_id: epic.id, sort_by: 'manual', limit: 10 })),
+                   ['Phase 2', 'Phase 1.1', 'Phase 1.2']);
+  t.task_reorder({ epic_id: epic.id, ordered_ids: [a.id, b.id, c.id] });
+});
+
+test('reorder refuses tasks from another epic', () => {
+  const stray = t.task_create({ epic_id: other.id, title: 'elsewhere' });
+  assert.throws(() => t.task_reorder({ epic_id: epic.id, ordered_ids: [stray.id] }), /do not belong/);
+});
+
+test('reorder on an epic with no tasks is an error, not a silent no-op', () => {
+  const empty = t.epic_create({ project_id: project.id, name: 'Empty' });
+  assert.throws(() => t.task_reorder({ epic_id: empty.id, ordered_ids: [] }), /no tasks/);
+});
+
+test('reorder positions are 1..n', () => {
+  const rows = t.task_list({ epic_id: epic.id, sort_by: 'manual', limit: 10 });
+  assert.deepEqual(rows.map((r) => r.sort_order), [1, 2, 3]);
+});
+
+/* ---------- dependencies re-evaluating in both directions ---------- */
+
+test('a task with an unmet dependency is auto-blocked', () => {
+  const blocker = t.task_create({ epic_id: epic.id, title: 'blocker' });
+  const waiter = t.task_create({ epic_id: epic.id, title: 'waiter', depends_on: [blocker.id] });
+  assert.equal(t.task_get({ id: waiter.id }).status, 'blocked');
+  return { blocker, waiter };
+});
+
+test('finishing the blocker unblocks it', () => {
+  const blocker = t.task_list({ limit: 30 }).find((x) => x.title === 'blocker');
+  const waiter = t.task_list({ limit: 30, include_deleted: true }).find((x) => x.title === 'waiter');
+  t.task_update({ id: blocker.id, status: 'done' });
+  assert.equal(t.task_get({ id: waiter.id }).status, 'todo');
+});
+
+test('REOPENING a finished blocker blocks it again', () => {
+  // Previously this left the waiter in todo with an unmet dependency: the
+  // downstream re-evaluation only ran when a task became done.
+  const blocker = t.task_list({ limit: 30 }).find((x) => x.title === 'blocker');
+  const waiter = t.task_list({ limit: 30 }).find((x) => x.title === 'waiter');
+  t.task_update({ id: blocker.id, status: 'in_progress' });
+  assert.equal(t.task_get({ id: waiter.id }).status, 'blocked');
+});
+
+test('and finishing it again releases the waiter', () => {
+  const blocker = t.task_list({ limit: 30 }).find((x) => x.title === 'blocker');
+  const waiter = t.task_list({ limit: 30, include_deleted: true }).find((x) => x.title === 'waiter');
+  t.task_update({ id: blocker.id, status: 'done' });
+  assert.equal(t.task_get({ id: waiter.id }).status, 'todo');
+});
+
+/* ---------- cycles ---------- */
+
+test('a circular task dependency is refused, naming the loop', () => {
+  // Subtasks refused these from the start; tasks accepted them, and the
+  // auto-blocking then left every task in the loop permanently blocked.
+  const x = t.task_create({ epic_id: epic.id, title: 'cycle-x' });
+  const y = t.task_create({ epic_id: epic.id, title: 'cycle-y' });
+  t.task_update({ id: y.id, depends_on: [x.id] });
+  assert.throws(() => t.task_update({ id: x.id, depends_on: [y.id] }), /circular task dependency/);
+  assert.throws(() => t.task_update({ id: x.id, depends_on: [y.id] }), new RegExp('#' + x.id));
+});
+
+test('a longer task cycle is caught too', () => {
+  const x = t.task_create({ epic_id: epic.id, title: 'c1' });
+  const y = t.task_create({ epic_id: epic.id, title: 'c2' });
+  const z = t.task_create({ epic_id: epic.id, title: 'c3' });
+  t.task_update({ id: y.id, depends_on: [x.id] });
+  t.task_update({ id: z.id, depends_on: [y.id] });
+  assert.throws(() => t.task_update({ id: x.id, depends_on: [z.id] }), /circular/);
+});
+
+test('self-dependency is dropped rather than erroring', () => {
+  const solo = t.task_create({ epic_id: epic.id, title: 'solo' });
+  t.task_update({ id: solo.id, depends_on: [solo.id] });
+  assert.equal(t.task_get({ id: solo.id }).depends_on.length, 0);
+});
+
+test('legitimate chains still work', () => {
+  const one = t.task_create({ epic_id: epic.id, title: 'chain-1' });
+  const two = t.task_create({ epic_id: epic.id, title: 'chain-2', depends_on: [one.id] });
+  const three = t.task_create({ epic_id: epic.id, title: 'chain-3', depends_on: [two.id] });
+  assert.equal(t.task_get({ id: three.id }).status, 'blocked');
+  t.task_update({ id: one.id, status: 'done' });
+  assert.equal(t.task_get({ id: two.id }).status, 'todo');
+  assert.equal(t.task_get({ id: three.id }).status, 'blocked', 'still waiting on chain-2');
+});
+
+test('subtask cycles are still refused after sharing the implementation', () => {
+  const host = t.task_create({ epic_id: epic.id, title: 'host' });
+  const subs = t.subtask_create({ task_id: host.id, titles: ['s1', 's2'] });
+  t.subtask_update({ id: subs[1].id, depends_on: [subs[0].id] });
+  assert.throws(() => t.subtask_update({ id: subs[0].id, depends_on: [subs[1].id] }),
+                /circular subtask dependency/);
+});
+
+test('clearing every dependency releases a task the system had blocked', () => {
+  // This used to strand it: with no dependencies left there was nothing that
+  // could ever re-evaluate it, so it sat in `blocked` permanently.
+  const blocker = t.task_create({ epic_id: epic.id, title: 'clear-blocker' });
+  const waiter = t.task_create({ epic_id: epic.id, title: 'clear-waiter', depends_on: [blocker.id] });
+  assert.equal(t.task_get({ id: waiter.id }).status, 'blocked');
+  t.task_update({ id: waiter.id, depends_on: [] });
+  assert.equal(t.task_get({ id: waiter.id }).status, 'todo');
+});
+
+test('but a task blocked by hand stays blocked', () => {
+  // `blocked` is also a status a person can set deliberately, and clearing it
+  // as a side effect of unrelated dependency traffic would be wrong.
+  const manual = t.task_create({ epic_id: epic.id, title: 'manually blocked' });
+  t.task_update({ id: manual.id, status: 'blocked' });
+  const unrelated = t.task_create({ epic_id: epic.id, title: 'unrelated' });
+  t.task_update({ id: unrelated.id, status: 'done' });
+  assert.equal(t.task_get({ id: manual.id }).status, 'blocked');
+});

--- a/test/tokens.test.js
+++ b/test/tokens.test.js
@@ -71,7 +71,7 @@ test('slimming measurably shrinks the payload', () => {
 
 test('every tool definition carries safety annotations', async () => {
   const defs = await loadDefinitions();
-  assert.equal(defs.length, 38);
+  assert.equal(defs.length, 39);
   for (const def of defs) {
     assert.ok(def.annotations, `${def.name} is missing annotations`);
     assert.equal(typeof def.annotations.readOnlyHint, 'boolean', `${def.name} readOnlyHint`);
@@ -85,7 +85,7 @@ test('read-only tools are annotated as such', async () => {
   for (const name of ['task_get', 'task_list', 'comment_list', 'tracker_dashboard', 'epic_list']) {
     assert.equal(byName[name].annotations.readOnlyHint, true, `${name} should be readOnly`);
   }
-  for (const name of ['task_create', 'comment_delete', 'comment_restore', 'epic_update', 'task_lock_description', 'subtask_reorder', 'epic_archive', 'task_delete', 'task_restore']) {
+  for (const name of ['task_create', 'comment_delete', 'comment_restore', 'epic_update', 'task_lock_description', 'subtask_reorder', 'epic_archive', 'task_delete', 'task_restore', 'task_reorder']) {
     assert.equal(byName[name].annotations.readOnlyHint, false, `${name} should not be readOnly`);
   }
 });

--- a/test/web.test.js
+++ b/test/web.test.js
@@ -158,6 +158,20 @@ test('a same-origin write is allowed', async () => {
   assert.equal(res.status, 200);
 });
 
+test('every write the UI issues is actually whitelisted', async () => {
+  // task_reorder shipped in the page before it was added to the server's
+  // whitelist, so drag-to-reorder silently did nothing.
+  const { PAGE } = await import('../dist/web/ui.js');
+  const used = [...PAGE.matchAll(/act\('([a-z_]+)'/g)].map((m) => m[1]);
+  assert.ok(used.length > 5, 'expected the page to call several tools');
+  for (const tool of [...new Set(used)]) {
+    const res = await post(editable.base, { tool, args: {} });
+    const body = await res.json();
+    assert.ok(!/Unknown or disallowed/.test(body.error ?? ''),
+      `the page calls ${tool}, but the server refuses it as not whitelisted`);
+  }
+});
+
 test('only whitelisted tools can be invoked', async () => {
   for (const tool of ['tracker_import', 'constructor', '__proto__', 'toString', '']) {
     const res = await post(editable.base, { tool, args: {} });


### PR DESCRIPTION
Closes #37 — reported by @rusak47. Both reports were real, and re-checking them against the code turned up **three defects nobody had reported**.

## 1. Ordering — the cause wasn't what the triage said

Not a missing reorder tool. `task_list` defaults to `sort_by: 'priority'`, where `sort_order` is only a **third-level tiebreaker**, and there was no way to sort by it at all. Reproduced:

```
agent sets sort_order 1, 2, 3
task_list default  ->  Phase 1.2 (so=2, critical)
                       Phase 1.1 (so=1, medium)
                       Phase 2   (so=3, low)
```

So an agent arranging tasks had no way to read that arrangement back. `sort_order` also had **no description at all**, leaving the direction to guesswork — which matches the report exactly.

Now: `task_reorder` mirrors `subtask_reorder`, `sort_by: "manual"` reads that order back, `sort_order` documents that lower sorts first, and tasks drag into place in the epic tree. **The default stays priority**, so nothing changes for callers who never asked.

## 2. Dependency editing

`task_update` has always accepted `depends_on` and enforced it — the drawer only *displayed* the result. There's now a picker to add and remove, and a blocked task says so **at the top** rather than only in a list halfway down.

One correction to my earlier triage on the issue: it claimed `blocked` is "manually-settable, not auto-derived" for tasks. **That was wrong** — tasks have always auto-blocked and auto-unblocked. Verified before building.

## 3. Three defects found on the way

All the same shape — the dependency graph not re-evaluated when it should be:

| | |
|---|---|
| **Reopening a finished blocker** | left dependents unblocked; the downstream pass only ran on the way *into* done |
| **Clearing the last dependency** | stranded an auto-blocked task in `blocked` forever, since nothing could re-evaluate it |
| **Task dependency cycles** | accepted, then auto-blocking put every task in the loop into `blocked` permanently |

Subtasks refused cycles from the start; tasks didn't. Both graphs now share one implementation rather than one having a check the other lacks.

The unblock fix is careful: `blocked` is *also* a status a person sets by hand, and those two cases are indistinguishable from state alone — so the dependency-edit path says which one it is, and a manual block is left alone. Tested both ways.

## 4. A shipped-but-inert feature

`task_reorder` reached the page **before** it was added to the web server's write whitelist, so dragging silently did nothing. My own UI test caught it.

There's now a test that walks every `act()` call in the page and asserts the server accepts it — that class of mistake is invisible from either side alone.

## Verification

- **234 tests** (was 214), including manual-order round-trip, both re-evaluation directions, cycles at 2 and 3 nodes, and manual-block preservation
- **20 live-DOM checks** — drag handles, manual order rendering, the blocked banner above the description, the picker, add and remove
- **84 e2e checks** against the packed tarball, extended to cover this
- Tool list **39 tools, 712 bytes/tool** — still under both budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
