### PR TITLE
feat(web): render markdown in descriptions, comments and notes (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ What you get:
 - **Board** — kanban across the five task statuses; drag a card to change its status
 - **Epics** — the full Epic → Task → Subtask tree, which is the fastest way to review a spec an agent just wrote
 - **Notes** and **Activity** — decisions and the complete change history
+- **Markdown** — descriptions, comments and notes render headings, tables, lists, code and links. Agent-written content is escaped before any markdown rule runs, so raw HTML can never reach the page, and only http/https/mailto links are followed
 - **Archived section** — archived epics collapse below a divider, with a "show archived (N)" toggle
 - **Task drawer** — edit any field, comment, remove or restore a comment, lock the description, drag subtasks into order, and set which subtasks wait on which. Each subtask has one control carrying its whole state (todo / in progress / done, or blocked), and the drawer resizes by dragging its edge
 - **Project switcher** — every project in the database, so one central `.tracker.db` covers all your repos; every tab, including Activity, is scoped to the selected project

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
   "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 35 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saga-mcp",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saga-mcp",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.11.0",
+  "version": "1.12.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -266,6 +266,37 @@ body.resizing { cursor: ew-resize; user-select: none; }
   font-size: 12px; color: var(--muted);
 }
 .hiddenbar hr { flex: 1; border: none; border-top: 1px dashed var(--border); }
+.md-p { margin: 0 0 8px; }
+.md-p:last-child { margin-bottom: 0; }
+.md-h { margin: 12px 0 6px; font-size: 14px; font-weight: 650; }
+.md-h:first-child { margin-top: 0; }
+h1.md-h { font-size: 17px; } h2.md-h { font-size: 15px; } h3.md-h { font-size: 14px; }
+.md-list { margin: 0 0 8px; padding-left: 20px; }
+.md-list li { margin: 2px 0; }
+.md-task { list-style: none; margin-left: -18px; }
+.md-quote {
+  margin: 0 0 8px; padding: 4px 10px; color: var(--muted);
+  border-left: 3px solid var(--border);
+}
+.md-hr { border: none; border-top: 1px solid var(--border); margin: 12px 0; }
+.md-code {
+  margin: 0 0 8px; padding: 8px 10px; overflow-x: auto;
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px;
+  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px; line-height: 1.45;
+}
+code {
+  background: var(--panel-2); border: 1px solid var(--border); border-radius: 4px;
+  padding: 0 4px; font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px;
+}
+.md-code code { background: none; border: none; padding: 0; font-size: inherit; }
+/* Wide tables scroll inside their own box rather than stretching the drawer. */
+.md-tablewrap { overflow-x: auto; margin: 0 0 8px; }
+.md-table { border-collapse: collapse; font-size: 12px; width: 100%; }
+.md-table th, .md-table td {
+  border: 1px solid var(--border); padding: 4px 8px; text-align: left; vertical-align: top;
+}
+.md-table th { background: var(--panel-2); font-weight: 600; white-space: nowrap; }
+.md-body a { color: var(--accent); }
 .toast {
   position: fixed; bottom: 18px; left: 50%; transform: translateX(-50%);
   background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
@@ -356,6 +387,185 @@ function tagPills(json) {
   }).join(' ');
 }
 function canEdit() { return !S.readOnly; }
+
+/* ---------- markdown ---------- */
+
+/**
+ * A small markdown renderer for descriptions, comments and notes.
+ *
+ * Content here is written by agents, so the order of operations is the whole
+ * security design: EVERY character is HTML-escaped first, and the markdown
+ * transformations then run over already-escaped text. Raw HTML in the source
+ * can never reach innerHTML, because by the time any rule matches, \`<\` is
+ * already \`&lt;\`. There is no sanitiser to get wrong and no allow-list to keep
+ * up to date.
+ *
+ * Links are the one place a payload could still hide, so their href is
+ * restricted to http, https and mailto.
+ */
+function mdEscape(text) {
+  return String(text).replace(/[&<>"']/g, function (c) {
+    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+  });
+}
+
+/** Only schemes that cannot execute. Anything else renders as plain text. */
+function mdSafeHref(href) {
+  var trimmed = href.trim();
+  // The href arrives already escaped, so &amp; must be read back as &.
+  var plain = trimmed.replace(/&amp;/g, '&');
+  if (/^(https?:\\/\\/|mailto:)/i.test(plain)) return plain;
+  if (/^[/#]/.test(plain)) return plain;
+  return null;
+}
+
+/** Inline rules, applied to already-escaped text. */
+function mdInline(text, codeStore) {
+  var out = text;
+
+  // Code spans first, stashed so no later rule edits their contents.
+  out = out.replace(/\`([^\`]+)\`/g, function (_m, code) {
+    codeStore.push('<code>' + code + '</code>');
+    return ' C' + (codeStore.length - 1) + ' ';
+  });
+
+  out = out.replace(/\\[([^\\]]+)\\]\\(([^)\\s]+)\\)/g, function (whole, label, href) {
+    var safe = mdSafeHref(href);
+    // A rejected link renders as the literal source rather than a bare label,
+    // so nothing is silently rewritten and the reader sees what was written.
+    if (!safe) return whole;
+    return '<a href="' + safe + '" target="_blank" rel="noopener noreferrer">' + label + '</a>';
+  });
+
+  out = out.replace(/\\*\\*([^*]+)\\*\\*/g, '<strong>$1</strong>');
+  out = out.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+  out = out.replace(/(^|[^*])\\*([^*\\n]+)\\*/g, '$1<em>$2</em>');
+  out = out.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+  return out;
+}
+
+function mdRestore(text, codeStore) {
+  return text.replace(/ C(\\d+) /g, function (_m, i) { return codeStore[Number(i)]; });
+}
+
+/** A pipe table needs a delimiter row underneath the header. */
+function mdIsTableDelimiter(line) {
+  return /^\\s*\\|?\\s*:?-{2,}:?\\s*(\\|\\s*:?-{2,}:?\\s*)*\\|?\\s*$/.test(line);
+}
+
+function mdSplitRow(line) {
+  var trimmed = line.trim().replace(/^\\|/, '').replace(/\\|$/, '');
+  return trimmed.split('|').map(function (cell) { return cell.trim(); });
+}
+
+function md(source) {
+  if (!source) return '';
+  var codeStore = [];
+  var lines = mdEscape(source).split('\\n');
+  var html = [];
+  var i = 0;
+
+  while (i < lines.length) {
+    var line = lines[i];
+
+    // fenced code — taken verbatim, no inline rules applied
+    var fence = /^\\s*\`\`\`(.*)$/.exec(line);
+    if (fence) {
+      var body = [];
+      i++;
+      while (i < lines.length && !/^\\s*\`\`\`/.test(lines[i])) { body.push(lines[i]); i++; }
+      i++;
+      html.push('<pre class="md-code"><code>' + body.join('\\n') + '</code></pre>');
+      continue;
+    }
+
+    if (/^\\s*$/.test(line)) { i++; continue; }
+
+    var hr = /^\\s*([-*_])(\\s*\\1){2,}\\s*$/.test(line);
+    if (hr) { html.push('<hr class="md-hr">'); i++; continue; }
+
+    var heading = /^(#{1,6})\\s+(.*)$/.exec(line);
+    if (heading) {
+      var level = heading[1].length;
+      html.push('<h' + level + ' class="md-h">' + mdInline(heading[2], codeStore) + '</h' + level + '>');
+      i++;
+      continue;
+    }
+
+    // table: a header row followed by a delimiter row
+    if (line.indexOf('|') >= 0 && i + 1 < lines.length && mdIsTableDelimiter(lines[i + 1])) {
+      var head = mdSplitRow(line);
+      i += 2;
+      var rows = [];
+      while (i < lines.length && lines[i].indexOf('|') >= 0 && !/^\\s*$/.test(lines[i])) {
+        rows.push(mdSplitRow(lines[i]));
+        i++;
+      }
+      var t = '<div class="md-tablewrap"><table class="md-table"><thead><tr>';
+      head.forEach(function (cell) { t += '<th>' + mdInline(cell, codeStore) + '</th>'; });
+      t += '</tr></thead><tbody>';
+      rows.forEach(function (row) {
+        t += '<tr>';
+        row.forEach(function (cell) { t += '<td>' + mdInline(cell, codeStore) + '</td>'; });
+        t += '</tr>';
+      });
+      html.push(t + '</tbody></table></div>');
+      continue;
+    }
+
+    var quote = /^\\s*&gt;\\s?(.*)$/.exec(line);
+    if (quote) {
+      var qbody = [quote[1]];
+      i++;
+      while (i < lines.length && /^\\s*&gt;\\s?(.*)$/.test(lines[i])) {
+        qbody.push(/^\\s*&gt;\\s?(.*)$/.exec(lines[i])[1]);
+        i++;
+      }
+      html.push('<blockquote class="md-quote">' + mdInline(qbody.join(' '), codeStore) + '</blockquote>');
+      continue;
+    }
+
+    var bullet = /^(\\s*)([-*+])\\s+(.*)$/.exec(line);
+    var numbered = /^(\\s*)(\\d+)[.)]\\s+(.*)$/.exec(line);
+    if (bullet || numbered) {
+      var ordered = !!numbered;
+      var items = [];
+      while (i < lines.length) {
+        var b = /^(\\s*)([-*+])\\s+(.*)$/.exec(lines[i]);
+        var n = /^(\\s*)(\\d+)[.)]\\s+(.*)$/.exec(lines[i]);
+        var m = ordered ? n : b;
+        if (!m) break;
+        var text = m[3];
+        // task-list checkboxes, rendered as a disabled box
+        var box = /^\\[([ xX])\\]\\s+(.*)$/.exec(text);
+        if (box) {
+          items.push('<li class="md-task"><input type="checkbox" disabled' +
+            (box[1] === ' ' ? '' : ' checked') + '> ' + mdInline(box[2], codeStore) + '</li>');
+        } else {
+          items.push('<li>' + mdInline(text, codeStore) + '</li>');
+        }
+        i++;
+      }
+      html.push('<' + (ordered ? 'ol' : 'ul') + ' class="md-list">' + items.join('') + '</' + (ordered ? 'ol' : 'ul') + '>');
+      continue;
+    }
+
+    // paragraph: consecutive non-blank lines that start no other block
+    var para = [line];
+    i++;
+    while (i < lines.length && !/^\\s*$/.test(lines[i]) &&
+           !/^(#{1,6})\\s/.test(lines[i]) && !/^\\s*\`\`\`/.test(lines[i]) &&
+           !/^\\s*([-*+])\\s/.test(lines[i]) && !/^\\s*\\d+[.)]\\s/.test(lines[i]) &&
+           !/^\\s*&gt;\\s?/.test(lines[i]) &&
+           !(lines[i].indexOf('|') >= 0 && i + 1 < lines.length && mdIsTableDelimiter(lines[i + 1]))) {
+      para.push(lines[i]);
+      i++;
+    }
+    html.push('<p class="md-p">' + mdInline(para.join(' '), codeStore) + '</p>');
+  }
+
+  return mdRestore(html.join(''), codeStore);
+}
 
 /* ---------- generic modal form ---------- */
 
@@ -581,7 +791,7 @@ function viewOverview() {
     pill('st', o.project.status) +
     '<span class="muted">' + (s.completion_pct || 0) + '% complete</span>' +
     (canEdit() ? '<button class="btn" id="editProject">Edit</button>' : '') + '</div>' +
-    (o.project.description ? '<pre class="body muted">' + esc(o.project.description) + '</pre>' : '') +
+    (o.project.description ? '<div class="body md-body muted">' + md(o.project.description) + '</div>' : '') +
     '<div style="margin-top:10px">' + progressBar(s.completion_pct) + '</div>' +
     '</div>';
 
@@ -702,7 +912,7 @@ function viewEpics() {
       '</div>';
     if (open) {
       h += '<div class="epic-body">' +
-        (e.description ? '<pre class="body muted" style="margin-bottom:10px">' + esc(e.description) + '</pre>' : '') +
+        (e.description ? '<div class="body md-body muted" style="margin-bottom:10px">' + md(e.description) + '</div>' : '') +
         '<div class="tlist">' +
         (list.length ? list.map(function (t) {
           var extra = t.subtask_count ? '☑ ' + t.subtask_done + '/' + t.subtask_count : '';
@@ -738,7 +948,7 @@ function viewNotes() {
         '</div>' +
         (n.related_entity_type ? '<div class="muted" style="font-size:12px;margin-top:2px">on ' +
           esc(n.related_entity_type) + ' #' + esc(n.related_entity_id) + '</div>' : '') +
-        '<pre class="body">' + esc(n.content) + '</pre>' +
+        '<div class="body md-body">' + md(n.content) + '</div>' +
         (tagPills(n.tags) ? '<div style="margin-top:8px">' + tagPills(n.tags) + '</div>' : '') +
         '</div>';
     }).join('');
@@ -903,7 +1113,7 @@ function drawTask() {
     '</h3>' +
     (locked ? '<div class="empty">Agents cannot rewrite this description while it is locked — ' +
               'they are told to comment instead.</div>' : '') +
-    (t.description ? '<pre class="body">' + esc(t.description) + '</pre>'
+    (t.description ? '<div class="body md-body">' + md(t.description) + '</div>'
                    : '<div class="empty">No description.</div>');
 
   h += '<h3>Subtasks <span class="muted">(' + t.subtasks.length + ')</span></h3>';
@@ -977,7 +1187,7 @@ function drawTask() {
       (ed ? (c.is_deleted ? '<button class="link" data-cmt-restore="' + c.id + '">restore</button>'
                           : '<button class="link" data-cmt-del="' + c.id + '">remove</button>') : '') +
       '</div>' +
-      '<pre class="body' + (c.is_deleted ? ' strike' : '') + '">' + esc(c.content) + '</pre>' +
+      '<div class="body md-body' + (c.is_deleted ? ' strike' : '') + '">' + md(c.content) + '</div>' +
       (c.is_deleted && c.delete_reason ? '<div class="hdr">reason: ' + esc(c.delete_reason) + '</div>' : '') +
       '</div>';
   }).join('') : '<div class="empty">No comments.</div>';
@@ -992,7 +1202,7 @@ function drawTask() {
   h += '<h3>Notes' + (ed ? ' <button class="btn" id="addTaskNote">+ Note</button>' : '') + '</h3>';
   h += t.notes.length ? t.notes.map(function (n) {
     return '<div class="cmt"><div class="hdr">' + esc(label(n.note_type)) + ' · ' + fmtDate(n.created_at) +
-      '</div><strong>' + esc(n.title) + '</strong><pre class="body">' + esc(n.content) + '</pre></div>';
+      '</div><strong>' + esc(n.title) + '</strong><div class="body md-body">' + md(n.content) + '</div></div>';
   }).join('') : '<div class="empty">None.</div>';
 
   if (t.activity.length) {

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -266,3 +266,115 @@ test('ordinary text inputs in a field still fill the row', () => {
   assert.ok(rule, 'the .field input width rule should still exist');
   assert.equal(rule.value, '100%');
 });
+
+/* ---------- markdown (#38) ---------- */
+
+/** The renderer as it actually ships, pulled out of the page and executed. */
+function renderer() {
+  const ctx = {
+    console, JSON, Object, Array, Number, String, Boolean, Date, Math, Set, Map,
+    RegExp, Error, isNaN, encodeURIComponent, parseInt, parseFloat,
+    setTimeout, clearTimeout,
+    document: { getElementById: () => element(), querySelector: () => null,
+                querySelectorAll: () => [], createElement: () => element(),
+                addEventListener() {}, body: element() },
+    window: { addEventListener() {}, location: { hash: '' } },
+    location: { hash: '' }, history: { replaceState() {} },
+    fetch: () => Promise.reject(new Error('no network in this test')),
+  };
+  ctx.globalThis = ctx;
+  createContext(ctx);
+  runInContext(script, ctx);
+  return ctx.md;
+}
+const md = renderer();
+const NL = String.fromCharCode(10);
+
+/** Every tag the renderer is permitted to emit. */
+const ALLOWED_TAGS = new Set(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'strong', 'em', 'del',
+  'code', 'pre', 'ul', 'ol', 'li', 'blockquote', 'hr', 'table', 'thead', 'tbody', 'tr', 'th',
+  'td', 'div', 'a', 'input', 'br']);
+
+test('markdown renders the constructs a report actually uses', () => {
+  assert.match(md('## Title'), /<h2/);
+  assert.match(md('**bold**'), /<strong>bold<\/strong>/);
+  assert.match(md('run `npm test` now'), /<code>npm test<\/code>/);
+  assert.match(md('- one' + NL + '- two'), /<ul[^>]*>.*<li>one<\/li>/);
+  assert.match(md('1. one' + NL + '2. two'), /<ol/);
+  const table = md('| a | b |' + NL + '|---|---|' + NL + '| 1 | 2 |');
+  assert.match(table, /<th>a<\/th>/);
+  assert.match(table, /<td>1<\/td>/);
+  assert.match(table, /md-tablewrap/, 'wide tables must scroll in their own box');
+});
+
+test('code spans keep their contents literal', () => {
+  assert.match(md('`**not bold**`'), /<code>\*\*not bold\*\*<\/code>/);
+  assert.ok(!md('```' + NL + '**x**' + NL + '```').includes('<strong>'));
+});
+
+test('raw HTML in the source can never reach the output as markup', () => {
+  // The whole security design: everything is escaped BEFORE any rule runs, so
+  // by the time a rule could match, `<` is already `&lt;`.
+  const attacks = [
+    '<script>alert(1)</script>',
+    '<img src=x onerror=alert(1)>',
+    '<iframe src="javascript:alert(1)">',
+    '**<svg onload=alert(1)>**',
+    '# <img src=x onerror=alert(1)>',
+    '| <script>x</script> | b |' + NL + '|---|---|' + NL + '| c | d |',
+    '> <script>alert(1)</script>',
+    '- <script>alert(1)</script>',
+    '<a href="javascript:alert(1)">x</a>',
+  ];
+  for (const attack of attacks) {
+    const out = md(attack);
+    const tags = [...out.matchAll(/<\/?([a-zA-Z][a-zA-Z0-9]*)/g)].map((m) => m[1].toLowerCase());
+    const stray = tags.find((t) => !ALLOWED_TAGS.has(t));
+    assert.equal(stray, undefined, `${attack} emitted <${stray}>`);
+    const handlers = [...out.matchAll(/<[^>]+?\s(on[a-z]+)=/gi)].map((m) => m[1]);
+    assert.deepEqual(handlers, [], `${attack} emitted an event handler`);
+  }
+});
+
+test('only non-executable link schemes become links', () => {
+  assert.match(md('[x](https://a.example)'), /href="https:\/\/a\.example"/);
+  assert.match(md('[x](https://a.example)'), /rel="noopener noreferrer"/);
+  for (const bad of ['javascript:alert(1)', 'JaVaScRiPt:alert(1)', 'vbscript:x',
+                     'data:text/html;base64,PHNjcmlwdD4=']) {
+    const out = md('[x](' + bad + ')');
+    assert.ok(!out.includes('<a '), `${bad} became a link`);
+    assert.ok(out.includes('[x]'), 'a rejected link should render as its literal source');
+  }
+});
+
+test('a dense real-world document renders without emitting anything unexpected', () => {
+  const doc = [
+    '## Report', '', 'Some **bold** and `code`.', '',
+    '| # | thing | note |', '|---|---|---|', '| 1 | `a` | **b** |', '| 2 | c | d |', '',
+    '- bullet with `code`', '- [x] done item', '', '1. first', '2. second', '',
+    '> a quote', '', '---', '', '```', '<script>not executed</script>', '```',
+  ].join(NL);
+  const out = md(doc);
+  const tags = [...out.matchAll(/<\/?([a-zA-Z][a-zA-Z0-9]*)/g)].map((m) => m[1].toLowerCase());
+  assert.ok(tags.every((t) => ALLOWED_TAGS.has(t)), 'unexpected tag: ' + tags.find((t) => !ALLOWED_TAGS.has(t)));
+  assert.match(out, /<table/);
+  assert.match(out, /<blockquote/);
+  assert.match(out, /<hr/);
+  assert.match(out, /checked/);
+  assert.ok(!/ C\d+ /.test(out), 'a code placeholder leaked into the output');
+});
+
+test('empty and missing input render as nothing', () => {
+  assert.equal(md(''), '');
+  assert.equal(md(null), '');
+  assert.equal(md(undefined), '');
+});
+
+test('every place prose is shown renders it as markdown', () => {
+  // Descriptions, comments and notes should behave the same; one of them still
+  // escaping into a <pre> would be an inconsistency users would trip over.
+  assert.ok(!/esc\(t\.description\)/.test(script), 'task description still raw-escaped');
+  assert.ok(!/esc\(c\.content\)/.test(script), 'comments still raw-escaped');
+  assert.ok(!/esc\(n\.content\)/.test(script), 'notes still raw-escaped');
+  assert.ok((script.match(/md-body/g) || []).length >= 6, 'expected markdown at every prose site');
+});


### PR DESCRIPTION
Closes #38 — reported by @rusak47, who attached a real document rather than describing one, which is what made the scope decision easy.

## Scoped from the actual sample

Counted what's in it instead of guessing at "basic markdown":

| construct | occurrences |
|---|---|
| inline code | **53** |
| table rows | **23** |
| bold | 20 |
| bullet / ordered list | 12 |
| headings | 5 |

So tables and inline code are what matter. Tables render properly and **scroll inside their own box** rather than stretching the drawer. Fenced code, blockquotes, links, rules, strikethrough and task-list checkboxes are supported too; anything unrecognised stays as written.

**No dependency** — saga-web's whole claim is a self-contained page with no external assets. The renderer is ~120 lines.

## The order of operations *is* the security design

There's no sanitiser here, deliberately. Every character is HTML-escaped **first**, and the markdown rules then run over already-escaped text. Raw HTML in the source cannot reach `innerHTML` because by the time any rule could match, `<` is already `&lt;`. No allow-list to keep current, no parser to outwit.

Links are the one place a payload could still hide, so schemes are restricted to `http`/`https`/`mailto`, and a **rejected link renders as its literal source** rather than being silently rewritten — the reader sees what was written.

This matters because the content is agent-written, not just user-written.

## Two things worth flagging about how it was built

**The template-literal trap.** `ui.ts` is one big template literal, where a lone `\d` collapses to `d` — which would have silently broken every regex in a regex-based renderer. So it was authored and tested as a standalone file, then embedded with backslashes doubled *mechanically*, and **the committed tests execute the embedded copy pulled back out of the built page**. Testing the standalone copy would have proved nothing about what ships.

**The tests assert a property, not a string.** My first attempt searched the output for `onerror`/`javascript:` and reported 6 false failures — because `&lt;img src=x onerror=…&gt;` is *correctly escaped* text and contains those substrings. The right assertion is structural: the output's tag set must be a subset of what the renderer may emit, and no attribute may begin with `on`.

## Verification

- **241 tests** (was 234), including 9 XSS vectors through every block type
- **20 live-DOM checks** rendering the reporter's actual 8KB document: no `<script>` created, no inline handlers on any element, no unsafe hrefs, nothing executed, and the attempted payload visible as text
- **84 e2e checks** against the packed tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)
