### PR TITLE
Report the real server version in the handshake; lock protocol negotiation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
   "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 35 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "saga-mcp",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saga-mcp",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "better-sqlite3": "^12.6.0"
       },
       "bin": {
@@ -34,11 +34,11 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
-      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.13.0",
-  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard \u2014 so LLMs never lose track.",
+  "version": "1.13.1",
+  "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard — so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -56,7 +56,7 @@
   "author": "spranab",
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "better-sqlite3": "^12.6.0"
   },
   "devDependencies": {

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -83,17 +83,20 @@ function mcp(env = {}) {
     const my = ++id; pending.set(my, res);
     child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: my, method, params }) + '\n');
   });
+  let handshake = null;
   const ready = (async () => {
-    await rpc('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e', version: '1' } });
+    const r = await rpc('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e', version: '1' } });
+    handshake = r.result;
     child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
   })();
+  const info = () => handshake;
   const call = async (name, args = {}) => {
     const r = await rpc('tools/call', { name, arguments: args });
     const text = r.result.content[0].text;
     if (r.result.isError) return { __error: text };
     try { return JSON.parse(text); } catch { return { __raw: text }; }
   };
-  return { rpc, call, ready, stderr: () => stderr, stop: () => child.kill() };
+  return { info, rpc, call, ready, stderr: () => stderr, stop: () => child.kill() };
 }
 
 const s = mcp();
@@ -255,6 +258,16 @@ badScope.stop();
 section('tool surface');
 const full = mcp();
 await full.ready;
+// The handshake reports a version read from package.json at runtime. That path
+// only resolves once the package is installed, which is what this gate exercises;
+// a unit test running from the source tree cannot catch it breaking.
+{
+  const info = full.info();
+  ok('the handshake names the installed package', info.serverInfo.name === pkg.name, info.serverInfo.name);
+  ok('and reports the version actually installed', info.serverInfo.version === pkg.version,
+     info.serverInfo.version + ' vs ' + pkg.version);
+}
+
 const fullTools = (await full.rpc('tools/list', {})).result.tools;
 ok('every tool is listed by default', fullTools.length === 40, String(fullTools.length));
 ok('every tool carries safety annotations', fullTools.every((t) => typeof t.annotations?.readOnlyHint === 'boolean'));

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.13.0",
+  "version": "1.13.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -83,8 +84,28 @@ function listedTools(): Tool[] {
   return ALL_TOOLS.filter((t) => CORE_TOOLS.has(t.name));
 }
 
+/**
+ * The version reported in the MCP handshake.
+ *
+ * This was hardcoded to '1.0.0' and stayed there through every release, so
+ * every client that logs or displays a server version has been reporting a
+ * number that was wrong from v1.0.1 onward — and it is the number a user would
+ * quote in a bug report. Reading package.json keeps the two from drifting
+ * again; test/server.test.js asserts they match.
+ */
+function serverVersion(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    return require('../package.json').version as string;
+  } catch {
+    // Never let a missing package.json stop the server from starting: an
+    // unknown version is a cosmetic problem, a failed handshake is not.
+    return '0.0.0';
+  }
+}
+
 const server = new Server(
-  { name: 'tracker', version: '1.0.0' },
+  { name: 'saga-mcp', version: serverVersion() },
   { capabilities: { tools: {} } }
 );
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -61,6 +61,72 @@ async function server(env) {
 }
 after(() => servers.forEach((s) => s.stop()));
 
+/**
+ * Protocol version negotiation.
+ *
+ * Issue #36 asks what happens when a client speaks a protocol revision newer
+ * than the one saga was built against. The answer should be: the connection
+ * still works, at the newest revision both sides know — never an error and
+ * never silence, because a client that cannot initialize cannot tell the user
+ * why.
+ *
+ * That behaviour comes from the SDK, which makes it exactly the kind of thing
+ * a dependency bump can change underneath us without any of our own code
+ * moving. Hence a test: it is a contract with our clients, not an SDK detail.
+ */
+const KNOWN_REVISIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25'];
+
+test('every protocol revision saga supports is echoed back unchanged', async () => {
+  for (const revision of KNOWN_REVISIONS) {
+    const s = startServer();
+    servers.push(s);
+    const res = await s.send('initialize', {
+      protocolVersion: revision, capabilities: {}, clientInfo: { name: 'test', version: '1' },
+    });
+    assert.equal(res.result.protocolVersion, revision, `asked for ${revision}`);
+  }
+});
+
+test('a client from the future is downgraded, not refused', async () => {
+  // 2026-07-28 is unreleased upstream (#36). A client that speaks it should
+  // still get a working session rather than a dead one.
+  const s = startServer();
+  servers.push(s);
+  const res = await s.send('initialize', {
+    protocolVersion: '2026-07-28', capabilities: {}, clientInfo: { name: 'future', version: '1' },
+  });
+  assert.ok(!res.error, `initialize failed: ${JSON.stringify(res.error)}`);
+  assert.equal(res.result.protocolVersion, KNOWN_REVISIONS[KNOWN_REVISIONS.length - 1]);
+
+  // And the session is genuinely usable, not merely established.
+  const tools = await s.send('tools/list', {});
+  assert.equal(tools.result.tools.length, 40);
+});
+
+test('a nonsense protocol version still yields a usable session', async () => {
+  const s = startServer();
+  servers.push(s);
+  const res = await s.send('initialize', {
+    protocolVersion: 'banana', capabilities: {}, clientInfo: { name: 'broken', version: '1' },
+  });
+  assert.ok(!res.error);
+  assert.equal(res.result.protocolVersion, KNOWN_REVISIONS[KNOWN_REVISIONS.length - 1]);
+});
+
+test('the server names itself and its version in the handshake', async () => {
+  const s = startServer();
+  servers.push(s);
+  const res = await s.send('initialize', {
+    protocolVersion: '2025-11-25', capabilities: {}, clientInfo: { name: 'test', version: '1' },
+  });
+  const { readFileSync } = await import('node:fs');
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  assert.equal(res.result.serverInfo.version, pkg.version,
+    'the handshake version should track package.json, so clients can report it accurately');
+  assert.equal(res.result.serverInfo.name, pkg.name,
+    'the handshake name should be the name people install, not an internal one');
+});
+
 test('tools/list returns every tool by default', async () => {
   const s = await server();
   const res = await s.send('tools/list', {});


### PR DESCRIPTION
Found while checking whether #36 is still blocked upstream. It is — but the check turned up a real bug on the way.

## The handshake reported the wrong version

`serverInfo` was hardcoded:

```ts
new Server({ name: 'tracker', version: '1.0.0' }, ...)
```

and never moved. **Every MCP client that logs or displays a server version has been told `1.0.0` since v1.0.1** — including in whatever a user would paste into a bug report. It now reads `package.json` at runtime, so the two cannot drift again, with a fallback so a missing `package.json` can never stop the server booting: an unknown version is cosmetic, a failed handshake is not.

The name is now the one people actually install. Nothing consumed the old value — client tool namespacing comes from the config key, not this field (checked before changing it).

Worth noting how this surfaced: **a test written on spec, not a report.** And a unit test alone would not have been enough — the `../package.json` path only resolves once the package is installed, so the assertion also runs in `scripts/e2e.mjs` against the packed tarball.

## Protocol negotiation is now pinned

#36 asks what happens when a client speaks a revision newer than the one saga was built against. Probed over the real transport:

| client asks | server answers |
|---|---|
| 2024-11-05 | 2024-11-05 |
| 2025-03-26 | 2025-03-26 |
| 2025-06-18 | 2025-06-18 |
| 2025-11-25 | 2025-11-25 |
| **2026-07-28** (unreleased) | 2025-11-25 |
| `banana` | 2025-11-25 |

The behaviour is already right: downgrade, never refuse. A client that cannot initialize cannot tell its user why. But that comes entirely from the SDK, which makes it precisely the kind of thing a dependency bump changes underneath us with none of our own code moving — so it is now a contract with our clients rather than an SDK detail. The future-revision test also asserts the session is genuinely *usable* afterwards, not merely established.

## SDK 1.26.0 → 1.30.0

Fixes only, no breaking changes. I checked the one that could plausibly matter for a stdio server — the new stdio buffer limit — and it is 10MB on the **read** buffer, so it caps what clients send us, not what we return. Only `tracker_import` could approach it, and 10MB of JSON is a very large import.

Also confirmed from the published 1.30.0 source (not assumed) that upstream still tops out at `2025-11-25`, so **#36 stays blocked** — there is nothing to implement yet.

## Verification

259 unit tests, 90 end-to-end checks driving the packed tarball's real binaries over stdio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)