### PR TITLE
Filter the dependency picker, and never hide a selected row

### DIFF
--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -236,6 +236,18 @@ body.resizing { cursor: ew-resize; user-select: none; }
 .checklist { max-height: 220px; overflow-y: auto; border: 1px solid var(--border); border-radius: 8px; padding: 6px 8px; }
 .checkrow { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 13px; cursor: pointer; }
 .checkrow input[type=checkbox] { width: auto; flex: none; margin: 0; }
+/* .checkrow sets display:flex, which has the same specificity as a bare
+   [hidden] rule -- so source order alone would decide whether a filtered-out
+   row actually disappears. Same trap as #25. Be explicit. */
+.checkrow[hidden] { display: none; }
+.filterrow { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+.filterrow input[type=search] {
+  flex: 1; min-width: 0; font: inherit; padding: 5px 8px;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: var(--panel); color: var(--text);
+}
+.filterrow .scopetoggle { flex: none; cursor: pointer; white-space: nowrap; color: var(--muted); }
+.checkcount { font-size: 11px; color: var(--muted); margin-top: 4px; }
 .checkrow span { flex: 1; min-width: 0; }
 .sub .handle { cursor: grab; color: var(--muted); user-select: none; font-size: 12px; }
 /* One control per subtask carrying its whole state: todo / in progress / done,
@@ -621,14 +633,32 @@ function modal(title, fields, submitLabel, onSubmit) {
       });
       h += '</select>';
     } else if (f.type === 'checkboxes') {
+      // A project-wide candidate list gets long fast (#45). When the field asks
+      // for it, offer a keyword filter and an optional scope toggle. Filtering
+      // is presentation only: the boxes stay in the DOM, so what is submitted
+      // never depends on what happens to be visible.
+      if (f.filterable) {
+        h += '<div class="filterrow">' +
+             '<input type="search" id="q_' + f.key + '" placeholder="' +
+               esc(f.filterPlaceholder || 'Filter by keyword') + '" autocomplete="off">' +
+             (f.scopeLabel
+               ? '<label class="checkrow scopetoggle"><input type="checkbox" id="s_' + f.key + '"' +
+                 (f.scopeOn ? ' checked' : '') + '> <span>' + esc(f.scopeLabel) + '</span></label>'
+               : '') +
+             '</div>';
+      }
       h += '<div id="f_' + f.key + '" class="checklist">';
       (f.options || []).forEach(function (o) {
         var on = (f.value || []).indexOf(o.value) >= 0;
-        h += '<label class="checkrow"><input type="checkbox" value="' + esc(o.value) + '"' +
+        h += '<label class="checkrow" data-search="' + esc(String(o.text).toLowerCase()) + '"' +
+             (o.scope === undefined ? '' : ' data-scope="' + esc(o.scope) + '"') +
+             '><input type="checkbox" value="' + esc(o.value) + '"' +
              (on ? ' checked' : '') + '> <span>' + esc(o.text) + '</span></label>';
       });
-      if (!(f.options || []).length) h += '<div class="empty">No other subtasks yet.</div>';
+      if (!(f.options || []).length) h += '<div class="empty">Nothing to choose from yet.</div>';
+      h += '<div class="empty" id="none_' + f.key + '" hidden>No match.</div>';
       h += '</div>';
+      if (f.filterable) h += '<div class="checkcount" id="n_' + f.key + '"></div>';
     } else if (f.type === 'tags') {
       h += '<input id="f_' + f.key + '" name="' + f.key + '" value="' + esc(v) +
            '" placeholder="comma, separated">';
@@ -647,6 +677,57 @@ function modal(title, fields, submitLabel, onSubmit) {
   m.innerHTML = h;
   document.body.appendChild(backdrop);
   document.body.appendChild(m);
+
+  /**
+   * Live filtering for a checkboxes field.
+   *
+   * The one rule that matters: a CHECKED row is never hidden. Filtering only
+   * changes what you can see, while the submit reads every checked box in the
+   * DOM -- so hiding a selected item would leave the user unable to see or
+   * remove a dependency that is still being saved.
+   */
+  fields.forEach(function (f) {
+    if (f.type !== 'checkboxes' || !f.filterable) return;
+    var box = m.querySelector('#f_' + f.key);
+    var query = m.querySelector('#q_' + f.key);
+    var scope = m.querySelector('#s_' + f.key);
+    var none = m.querySelector('#none_' + f.key);
+    var count = m.querySelector('#n_' + f.key);
+    var rows = Array.prototype.slice.call(box.querySelectorAll('.checkrow'));
+
+    function applyFilter() {
+      var term = (query && query.value ? query.value : '').trim().toLowerCase();
+      var scoped = !!(scope && scope.checked);
+      // Count what the search actually matched separately from what is on
+      // screen. A selected row is shown regardless, so counting only visible
+      // rows would hide the fact that the keyword found nothing.
+      var matched = 0, shown = 0;
+      rows.forEach(function (row) {
+        var cb = row.querySelector('input');
+        var hit = (!term || row.getAttribute('data-search').indexOf(term) >= 0) &&
+                  (!scoped || String(row.getAttribute('data-scope')) === String(f.scopeValue));
+        if (hit) matched++;
+        var keep = hit || (cb && cb.checked);
+        row.hidden = !keep;
+        if (keep) shown++;
+      });
+      if (none) {
+        none.hidden = matched > 0;
+        none.textContent = shown > 0
+          ? 'No match — showing your current selections.'
+          : 'No match.';
+      }
+      if (count) {
+        count.textContent = shown === rows.length
+          ? rows.length + ' shown'
+          : shown + ' of ' + rows.length + ' shown (selected are always listed)';
+      }
+    }
+
+    if (query) query.addEventListener('input', applyFilter);
+    if (scope) scope.addEventListener('change', applyFilter);
+    applyFilter();
+  });
 
   var first = m.querySelector('input, textarea, select');
   if (first) first.focus();
@@ -1490,12 +1571,17 @@ document.addEventListener('click', function (ev) {
       if (x.id === self.id) return false;
       return x.status !== 'done' || current.indexOf(x.id) >= 0;
     }).map(function (x) {
-      return { value: x.id, text: '#' + x.id + '  ' + x.title + '  · ' + (x.epic_name || '') +
+      return { value: x.id, scope: x.epic_id,
+        text: '#' + x.id + '  ' + x.title + '  · ' + (x.epic_name || '') +
         (x.status === 'done' ? '  (done)' : '') };
     });
     return modal('“' + self.title + '” waits on…', [
       { key: 'depends_on', label: 'Tasks that must finish first — this one is blocked until they are done',
-        type: 'checkboxes', options: candidates, value: current }
+        type: 'checkboxes', options: candidates, value: current,
+        // The list is project-wide, so it gets long (#45). Both controls asked
+        // for: keyword filter, and a one-click narrowing to this task's epic.
+        filterable: true, filterPlaceholder: 'Filter by title, epic or #id',
+        scopeLabel: 'This epic only', scopeValue: self.epic_id, scopeOn: false }
     ], 'Save', function (values) {
       return act('task_update', { id: self.id, depends_on: values.depends_on })
         .then(function () { toast('Dependencies updated'); return refresh(); });

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -505,3 +505,73 @@ test('the critical pill keeps readable text on its fill in both themes', () => {
   assert.equal(inks.length, 2, 'critical ink should be defined for light and dark');
   assert.notEqual(inks[0], inks[1], 'the two themes need different ink or one of them is unreadable');
 });
+
+/* ---------- dependency picker filtering (#45) ---------- */
+
+/**
+ * The dependency picker offers every unfinished task in the project, which
+ * @rusak47 reported gets unusably long. It now has a keyword filter and a
+ * "this epic only" toggle.
+ *
+ * Filtering is presentation only -- the boxes stay in the DOM and the submit
+ * reads every checked one -- so the invariant that matters is that a CHECKED
+ * row is never hidden. Hiding a selected dependency would leave the user
+ * unable to see or remove something that is still being saved.
+ */
+test('a filtered-out row is actually hidden by the stylesheet', () => {
+  // .checkrow sets display:flex, which ties with a bare [hidden] on
+  // specificity -- source order alone would decide. Same trap as #25, so
+  // resolve the cascade rather than trusting where the rule happens to sit.
+  const displays = declarationsOf('display').filter(
+    (d) => d.sel === '.checkrow' || d.sel === '.checkrow[hidden]'
+  );
+  assert.ok(displays.length >= 2, 'expected both a .checkrow and a .checkrow[hidden] display rule');
+  const won = winner(displays);
+  assert.equal(won.sel, '.checkrow[hidden]');
+  assert.equal(won.value, 'none');
+});
+
+test('the filter is presentation only: hidden boxes still submit', () => {
+  // The submit reads input:checked across the whole list, which ignores
+  // visibility. This is the behaviour the "never hide a checked row" rule
+  // depends on, so pin it.
+  assert.match(script, /querySelectorAll\('input:checked'\)/);
+});
+
+test('a checked row is never hidden by the filter', () => {
+  // The invariant, read off the filter itself: the checked state short-circuits
+  // the keyword and scope tests.
+  const fn = script.slice(script.indexOf('function applyFilter()'));
+  const body = fn.slice(0, fn.indexOf('\n    }'));
+  assert.match(body, /var keep = hit \|\| \(cb && cb\.checked\);/,
+    'a row is kept if it matched OR is checked -- the checked case must not be conditional');
+});
+
+test('the picker asks for a filter and a scope toggle', () => {
+  assert.match(script, /filterable: true/);
+  assert.match(script, /scopeLabel: 'This epic only'/);
+  assert.match(script, /scopeValue: self\.epic_id/);
+});
+
+test('candidate rows carry what the filter matches on', () => {
+  // data-search is lowercased at render time so the filter can do a plain
+  // substring test, and data-scope carries the epic for the toggle.
+  assert.match(script, /data-search="' \+ esc\(String\(o\.text\)\.toLowerCase\(\)\)/);
+  assert.match(script, /data-scope="' \+ esc\(o\.scope\)/);
+  assert.match(script, /scope: x\.epic_id/);
+});
+
+test('the scope toggle starts off, so nothing is hidden until asked', () => {
+  assert.match(script, /scopeOn: false/);
+});
+
+test('"no match" describes the search, not the selections still on screen', () => {
+  // A selected row is always shown, so counting visible rows would report a
+  // match when the keyword actually found nothing. The two are counted apart.
+  const fn = script.slice(script.indexOf('function applyFilter()'));
+  const body = fn.slice(0, fn.indexOf('\n    }'));
+  assert.match(body, /var matched = 0, shown = 0;/);
+  assert.match(body, /none\.hidden = matched > 0;/,
+    'the note must key off what matched, not off what is visible');
+  assert.match(body, /showing your current selections/);
+});


### PR DESCRIPTION
Closes #45.

@rusak47 asked for either a checkbox limiting dependency candidates to the current epic, or a keyword filter — and judged the filter the more robust option since cross-epic dependencies are sometimes exactly what you want. Both are here: the filter for the general case, the toggle for the common one.

The filter matches **title, epic name and `#id`**, since all three are things you'd reach for. The toggle starts off, so nothing is hidden until asked.

## The rule that turned out to matter

**A selected row is never hidden.**

Filtering is presentation only — the submit reads every checked box in the DOM, ignoring visibility. So hiding a selected item would leave you unable to see or remove a dependency that is *still being saved*.

Worse than confusing: the obvious implementation **silently deletes data**. Scope to this epic, hit save, and a cross-epic dependency you can no longer see is gone. I built it the naive way to confirm, and watched this fail:

```
FAIL  and the pre-existing dependency is not lost  -- ["Wire the OAuth callback"]
                                    (Email the receipt was silently dropped)
```

Seven of the 23 live checks fail without the rule.

## Two smaller things that fell out

**A specificity tie, same shape as #25.** `.checkrow` sets `display: flex`, which ties with a bare `[hidden]` rule — source order alone would decide whether a filtered-out row actually disappeared. `.checkrow[hidden]` is now explicit, and the cascade is resolved in a test rather than trusted.

**"No match" now describes the search, not the screen.** Because a selected row is always shown, counting visible rows would claim a match when the keyword found nothing. `matched` and `shown` are counted separately, and the note reads *"No match — showing your current selections."*

## Verification

- **275 unit tests** (8 new), including the cascade resolution and the never-hide invariant read off the implementation.
- **23 live checks** against a running server driving the real picker: typing keywords, matching on epic and id, toggling scope, ticking a row and then filtering it away before saving.
- Breaking the invariant on purpose fails 7 of those checks, including the data-loss one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)