### PR TITLE
Follow a deliberate task order, and cross out finished tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,16 +428,26 @@ Unblocking #7 'the keystone' would release 3 of them.
 
 ## Ordering and dependencies
 
-`task_list` sorts by priority by default, which is usually what an agent wants but ignores any
-order you arranged by hand. `sort_by: "manual"` reads back the order `task_reorder` set:
+**A deliberate order wins over a guess.** `task_list` sorts by priority until someone arranges an
+epic, and from then on it follows the arrangement:
 
 ```
 task_reorder({ epic_id: 2, ordered_ids: [8, 5, 6] })
-task_list({ epic_id: 2, sort_by: "manual" })     # 8, 5, 6
+task_list({ epic_id: 2 })                        # 8, 5, 6 — the plan, in order
+task_list({ epic_id: 2, sort_by: "priority" })   # priority, if that is what you want
 ```
 
+Priority is a reasonable guess about what matters; a sequence someone wrote down is not a guess.
+An agent handed a plan should start at the beginning of it, not at whichever step happens to be
+marked critical.
+
+Nothing changes for epics nobody has arranged — those sort by priority exactly as before, and an
+explicit `sort_by` is always obeyed literally.
+
 Anything omitted from `ordered_ids` keeps its relative position at the end. `sort_order` runs
-ascending — lower sorts first — and in the web UI you can drag tasks into place inside an epic.
+ascending — lower sorts first — and a task created *after* an arrangement has no place in it, so it
+lands at the end rather than the front. In the web UI you can drag tasks into place inside an epic,
+and finished ones are struck through.
 
 Task dependencies auto-block and auto-unblock:
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "saga-mcp",
   "display_name": "Saga — Project Tracker for AI Agents",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy and activity logging — so LLMs never lose track.",
   "long_description": "Saga gives your AI assistant a structured SQLite database to track projects, epics, tasks, subtasks, notes, and decisions across sessions. No more scattered markdown files — one `tracker_dashboard` call gives full project context to resume work.\n\n**Key features:**\n- Full hierarchy: Projects > Epics > Tasks > Subtasks\n- Task dependencies: Express sequencing with auto-block/unblock\n- Comments: Threaded discussions on tasks for decision trails, with reversible soft-delete\n- Templates: Reusable task sets with variable substitution\n- Dashboard: One tool call gives full overview with natural language summary\n- SQLite: Self-contained `.tracker.db` file per project — zero setup\n- Activity log: Every mutation is automatically tracked\n- Notes system: Decisions, context, meeting notes, blockers\n- Batch operations: Create multiple subtasks or update multiple tasks in one call\n- 35 focused tools with safety annotations\n- Web UI: `saga-web` serves a local dashboard for browsing and editing the same database\n- Import/export: Full project backup and migration as JSON",
   "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "saga-mcp",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "saga-mcp",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "saga-mcp",
   "mcpName": "io.github.spranab/saga-mcp",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "A Jira-like project tracker MCP server for AI agents. SQLite-backed, per-project scoped, with full hierarchy (Projects > Epics > Tasks > Subtasks), activity logging, and a dashboard — so LLMs never lose track.",
   "type": "module",
   "main": "dist/index.js",

--- a/scripts/e2e.mjs
+++ b/scripts/e2e.mjs
@@ -191,8 +191,20 @@ section('ordering and dependencies');
   const manual = await s.call('task_list', { epic_id: orderEpic.id, sort_by: 'manual', limit: 10 });
   ok('task_reorder + sort_by manual round-trips', manual.map((t) => t.title).join(',') === 'step one,step two',
      manual.map((t) => t.title).join(','));
-  const byPriority = await s.call('task_list', { epic_id: orderEpic.id, limit: 10 });
-  ok('the default sort is still priority', byPriority[0].title === 'step two');
+  // #48: once an epic has been arranged, the default follows the arrangement.
+  // 'step two' is critical and would otherwise lead; the point is that a
+  // deliberate order outranks a guess.
+  const byDefault = await s.call('task_list', { epic_id: orderEpic.id, limit: 10 });
+  ok('the default follows a deliberate arrangement', byDefault[0].title === 'step one',
+     byDefault.map((t) => t.title).join(','));
+  const byPriority = await s.call('task_list', { epic_id: orderEpic.id, sort_by: 'priority', limit: 10 });
+  ok('an explicit priority sort is still obeyed literally', byPriority[0].title === 'step two',
+     byPriority.map((t) => t.title).join(','));
+  const late = await s.call('task_create', { epic_id: orderEpic.id, title: 'added later', priority: 'critical' });
+  const withLate = await s.call('task_list', { epic_id: orderEpic.id, limit: 10 });
+  ok('a task added after the arrangement lands at the end, not the head',
+     withLate[withLate.length - 1].title === 'added later', withLate.map((t) => t.title).join(','));
+  await s.call('task_delete', { id: late.id, reason: 'gate fixture' });
 
   await s.call('task_update', { id: two.id, depends_on: [one.id] });
   ok('a dependent task auto-blocks', (await s.call('task_get', { id: two.id })).status === 'blocked');

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/spranab/saga-mcp",
     "source": "github"
   },
-  "version": "1.15.0",
+  "version": "1.16.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "saga-mcp",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -80,8 +80,7 @@ export const definitions: Tool[] = [
         sort_by: {
           type: 'string',
           enum: ['priority', 'created', 'due_date', 'status', 'manual'],
-          default: 'priority',
-          description: 'priority (critical first), created (newest first), due_date (earliest first), status (actionable first), manual (the order set by task_reorder)',
+          description: 'Omit to follow the arrangement set by task_reorder, falling back to priority. priority (critical first), created (newest), due_date (earliest), status (actionable first), manual.',
         },
         limit: { type: 'integer', default: 50, description: 'Max results' },
       },
@@ -90,7 +89,7 @@ export const definitions: Tool[] = [
   {
     name: 'task_reorder',
     description:
-      "Set the order of an epic's tasks. Omitted IDs keep their relative order at the end. Read it back with task_list sort_by=\"manual\"; the default sort is priority, which ignores this.",
+      "Set the order of an epic's tasks. Omitted IDs keep their relative order at the end. task_list then follows this arrangement by default.",
     annotations: { title: 'Reorder Tasks', readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     inputSchema: {
       type: 'object',
@@ -294,6 +293,24 @@ function handleTaskCreate(args: Record<string, unknown>) {
 const PRIORITY_ORDER = "CASE t.priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 END";
 const STATUS_ORDER = "CASE t.status WHEN 'blocked' THEN 0 WHEN 'in_progress' THEN 1 WHEN 'review' THEN 2 WHEN 'todo' THEN 3 WHEN 'done' THEN 4 END";
 
+/**
+ * task_reorder writes 1..N, so sort_order = 0 means "never placed". Those sort
+ * last rather than first: a task created after an arrangement was made has no
+ * position in it, and the head of a plan is the one place it certainly does
+ * not belong.
+ */
+const UNPLACED_LAST = 'CASE WHEN t.sort_order = 0 THEN 1 ELSE 0 END';
+
+/**
+ * The arrangement a human actually made, honoured across epics.
+ *
+ * Epics are grouped first because sort_order only means anything within one
+ * epic -- position 1 of epic A and position 1 of epic B are unrelated, so
+ * interleaving them by number would invent an order nobody set. Priority still
+ * decides between tasks that share a position, i.e. the unplaced ones.
+ */
+const ARRANGED = `e.sort_order, e.id, ${UNPLACED_LAST}, t.sort_order, ${PRIORITY_ORDER}, ${STATUS_ORDER}, t.created_at`;
+
 function getTaskOrderClause(sortBy: string): string {
   switch (sortBy) {
     case 'priority':
@@ -305,12 +322,24 @@ function getTaskOrderClause(sortBy: string): string {
     case 'created':
       return `t.created_at DESC`;
     case 'manual':
-      // The order a human or agent actually arranged, which every other mode
-      // treats as a tiebreaker at best.
-      return `t.sort_order, t.created_at`;
+      return `e.sort_order, e.id, ${UNPLACED_LAST}, t.sort_order, t.created_at`;
+    case 'arranged':
+      return ARRANGED;
     default:
       return `${PRIORITY_ORDER}, ${STATUS_ORDER}, t.sort_order, t.created_at`;
   }
+}
+
+/** Has anything in this result set been placed by task_reorder? */
+function hasArrangement(
+  db: ReturnType<typeof getDb>,
+  whereClauses: string[],
+  params: unknown[]
+): boolean {
+  const clauses = [...whereClauses, 't.sort_order != 0'];
+  const sql = `SELECT 1 FROM tasks t JOIN epics e ON e.id = t.epic_id
+               WHERE ${clauses.join(' AND ')} LIMIT 1`;
+  return db.prepare(sql).get(...params) !== undefined;
 }
 
 function handleTaskList(args: Record<string, unknown>) {
@@ -321,7 +350,7 @@ function handleTaskList(args: Record<string, unknown>) {
   const assignedTo = args.assigned_to as string | undefined;
   const tag = args.tag as string | undefined;
   const branchFilter = resolveBranch(args.branch);
-  const sortBy = (args.sort_by as string) ?? 'priority';
+  const explicitSort = args.sort_by as string | undefined;
   const limit = (args.limit as number) ?? 50;
 
   const whereClauses: string[] = [];
@@ -363,6 +392,21 @@ function handleTaskList(args: Record<string, unknown>) {
   }
 
   const whereStr = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+
+  /**
+   * Which order to use when the caller did not say (#48).
+   *
+   * Sorting by priority ignored a deliberate arrangement, so an agent handed a
+   * sequenced plan would start in the middle of it -- @rusak47's report had the
+   * list opening on "Phase 1.1" while the plan began at "Phase 0". Priority is
+   * the right guess only while nobody has expressed a better one.
+   *
+   * The test is exact rather than clever: if any task in this result was placed
+   * by task_reorder, follow the arrangement; otherwise sort exactly as before.
+   * An explicit sort_by is always obeyed literally -- asking for priority gets
+   * priority, arrangement or not.
+   */
+  const sortBy = explicitSort ?? (hasArrangement(db, whereClauses, params) ? 'arranged' : 'priority');
 
   const sql = `
     SELECT t.*,

--- a/src/web/ui.ts
+++ b/src/web/ui.ts
@@ -964,7 +964,11 @@ function taskLine(t, extra, opts) {
     (drag ? ' data-task-row="' + t.id + '" data-epic="' + t.epic_id + '" draggable="true"' : '') + '>' +
     (drag ? '<span class="thandle" title="Drag to reorder">⠿</span>' : '') +
     (t.status === 'blocked' ? blockedMark(t) : '<span class="dot st-' + esc(t.status) + '"></span>') +
-    '<span class="grow ellip">' + esc(t.title) + '</span>' +
+    // A finished task reads as struck through and dimmed (#49). Subtasks in the
+    // drawer already did this; the epic tree was the omission, so the same task
+    // looked finished in one place and open in another.
+    '<span class="grow ellip' + (t.status === 'done' ? ' muted strike' : '') + '">' +
+      esc(t.title) + '</span>' +
     (extra ? '<span class="muted" style="font-size:12px">' + extra + '</span>' : '') +
     (t.epic_name ? '<span class="muted ellip" style="font-size:12px;max-width:180px">' + esc(t.epic_name) + '</span>' : '') +
     pill('pr', t.priority) + '</div>';

--- a/test/page.test.js
+++ b/test/page.test.js
@@ -670,3 +670,30 @@ test('a template whose JSON could not be read says so instead of looking empty',
   });
   assert.match(html, /could not be read/);
 });
+
+/* ---------- finished tasks read as finished (#49) ---------- */
+
+test('a done task in the tree is struck through and dimmed', () => {
+  // Reported by @rusak47: subtasks in the drawer already rendered this way,
+  // so the same task looked finished in one place and open in another.
+  const { ctx } = runPage(emptyRoutes);
+  const html = ctx.taskLine({ id: 1, epic_id: 1, title: 'Shipped it', status: 'done', priority: 'low' }, '', {});
+  const span = /<span class="([^"]*)">Shipped it<\/span>/.exec(html);
+  assert.ok(span, 'title span not found in: ' + html);
+  assert.match(span[1], /strike/);
+  assert.match(span[1], /muted/);
+});
+
+test('an unfinished task is not struck through', () => {
+  const { ctx } = runPage(emptyRoutes);
+  for (const status of ['todo', 'in_progress', 'review']) {
+    const html = ctx.taskLine({ id: 2, epic_id: 1, title: 'Open', status: status, priority: 'low' }, '', {});
+    assert.ok(!/strike/.test(html), status + ' should not be struck: ' + html);
+  }
+});
+
+test('the strike matches how a done subtask already renders', () => {
+  // One treatment for one meaning; the two should not drift apart again.
+  assert.match(script, /' muted strike'/);
+  assert.match(css, /\.strike \{ text-decoration: line-through; \}/);
+});

--- a/test/sort-order.test.js
+++ b/test/sort-order.test.js
@@ -1,0 +1,130 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { tempDbPath, loadTools } from './helpers.js';
+
+/**
+ * task_list default ordering (#48).
+ *
+ * Reported by @rusak47: a deliberately sequenced plan came back scrambled,
+ * because the default sorted by priority and treated the arrangement as a
+ * third-level tiebreaker. The list opened on "Phase 1.1" while the plan began
+ * at "Phase 0" -- an agent following it would work the plan out of order,
+ * which is worse than a cosmetic complaint.
+ *
+ * The fix has to earn its keep twice: honour an arrangement when one exists,
+ * and change NOTHING for the far larger number of callers who never reorder.
+ */
+const t = await loadTools(tempDbPath('saga-sort48'));
+const project = t.project_create({ name: 'Sorting' });
+
+const titles = (rows) => rows.map((r) => r.title);
+
+/* ------------------------------------------------------------ untouched epic */
+
+const plain = t.epic_create({ project_id: project.id, name: 'Never reordered', status: 'in_progress' });
+t.task_create({ epic_id: plain.id, title: 'a low one', priority: 'low' });
+t.task_create({ epic_id: plain.id, title: 'a critical one', priority: 'critical' });
+t.task_create({ epic_id: plain.id, title: 'a medium one', priority: 'medium' });
+
+test('an epic nobody arranged still sorts by priority', () => {
+  const rows = t.task_list({ epic_id: plain.id, limit: 20 });
+  assert.deepEqual(titles(rows), ['a critical one', 'a medium one', 'a low one']);
+});
+
+test('and the default is byte for byte what sort_by=priority gives', () => {
+  // The whole safety argument for this change: callers who never reorder must
+  // see no difference at all.
+  const auto = t.task_list({ epic_id: plain.id, limit: 20 });
+  const explicit = t.task_list({ epic_id: plain.id, sort_by: 'priority', limit: 20 });
+  assert.equal(JSON.stringify(auto), JSON.stringify(explicit));
+});
+
+/* ------------------------------------------------------------ arranged epic */
+
+const planned = t.epic_create({ project_id: project.id, name: 'A real plan', status: 'in_progress' });
+const steps = ['Phase 0: prepare', 'Phase 1: rebase', 'Phase 2: reset'].map((title, i) =>
+  t.task_create({ epic_id: planned.id, title, priority: i === 1 ? 'critical' : 'low' })
+);
+t.task_reorder({ epic_id: planned.id, ordered_ids: steps.map((x) => x.id) });
+
+test('an arranged epic comes back in the arranged order by default', () => {
+  const rows = t.task_list({ epic_id: planned.id, limit: 20 });
+  assert.deepEqual(titles(rows), ['Phase 0: prepare', 'Phase 1: rebase', 'Phase 2: reset']);
+});
+
+test('the highest priority no longer jumps the queue it was placed in', () => {
+  // "Phase 1: rebase" is critical; before the fix it came first.
+  const rows = t.task_list({ epic_id: planned.id, limit: 20 });
+  assert.equal(rows[0].title, 'Phase 0: prepare');
+});
+
+test('asking for priority explicitly still gets priority', () => {
+  // An explicit sort_by is a direct instruction; the arrangement does not
+  // override it.
+  const rows = t.task_list({ epic_id: planned.id, sort_by: 'priority', limit: 20 });
+  assert.equal(rows[0].title, 'Phase 1: rebase');
+});
+
+test('a status sort is likewise untouched', () => {
+  const rows = t.task_list({ epic_id: planned.id, sort_by: 'status', limit: 20 });
+  assert.ok(rows.length === 3);
+});
+
+/* -------------------------------------------- a task added after the plan */
+
+test('a task created after the arrangement goes last, not first', () => {
+  // task_reorder writes 1..N, so a new task has sort_order 0. Sorted naively
+  // that is the smallest number and it would land at the head of the plan --
+  // the one place it certainly does not belong.
+  const late = t.task_create({ epic_id: planned.id, title: 'thought of later', priority: 'critical' });
+  const rows = t.task_list({ epic_id: planned.id, limit: 20 });
+  assert.equal(rows[rows.length - 1].title, 'thought of later');
+  assert.equal(rows[0].title, 'Phase 0: prepare');
+
+  const manual = t.task_list({ epic_id: planned.id, sort_by: 'manual', limit: 20 });
+  assert.equal(manual[manual.length - 1].title, 'thought of later',
+    'sort_by=manual should place it the same way');
+
+  t.task_delete({ id: late.id, reason: 'fixture' });
+});
+
+/* ------------------------------------------------------- across epics */
+
+test('two arranged epics do not interleave by position number', () => {
+  // Position 1 of one epic and position 1 of another are unrelated; ordering
+  // by the number alone would invent a sequence nobody set.
+  const other = t.epic_create({ project_id: project.id, name: 'Another plan', status: 'in_progress' });
+  const more = ['Other A', 'Other B'].map((title) => t.task_create({ epic_id: other.id, title }));
+  t.task_reorder({ epic_id: other.id, ordered_ids: more.map((x) => x.id) });
+
+  const rows = t.task_list({ project_id: project.id, limit: 50 });
+  const names = titles(rows);
+  const planIdx = names.map((n, i) => [n, i]).filter(([n]) => /^Phase/.test(n)).map(([, i]) => i);
+  const otherIdx = names.map((n, i) => [n, i]).filter(([n]) => /^Other/.test(n)).map(([, i]) => i);
+
+  const contiguous = (idx) => idx[idx.length - 1] - idx[0] === idx.length - 1;
+  assert.ok(contiguous(planIdx), 'one epic should stay together: ' + JSON.stringify(names));
+  assert.ok(contiguous(otherIdx), 'so should the other: ' + JSON.stringify(names));
+});
+
+test('an unarranged epic mixed in still orders its own tasks by priority', () => {
+  const rows = t.task_list({ project_id: project.id, limit: 50 });
+  const plainNames = titles(rows).filter((n) => /one$/.test(n));
+  assert.deepEqual(plainNames, ['a critical one', 'a medium one', 'a low one']);
+});
+
+/* ------------------------------------------------------- other filters */
+
+test('the arrangement survives a status filter', () => {
+  t.task_update({ id: steps[0].id, status: 'in_progress' });
+  const rows = t.task_list({ epic_id: planned.id, status: 'todo', limit: 20 });
+  assert.deepEqual(titles(rows), ['Phase 1: rebase', 'Phase 2: reset']);
+  t.task_update({ id: steps[0].id, status: 'todo' });
+});
+
+test('a filter that matches only unarranged tasks falls back to priority', () => {
+  // The detection runs against the same filters as the list, so a result set
+  // with nothing placed in it sorts the old way.
+  const rows = t.task_list({ epic_id: plain.id, limit: 20 });
+  assert.equal(rows[0].title, 'a critical one');
+});


### PR DESCRIPTION
Closes #48. Closes #49.

## #48 — `task_list` ignored an arrangement

Reported as a preference. It's worse than that. Reproduced with @rusak47's own plan:

| what the agent gets | the plan, as written |
|---|---|
| 1. Phase 1.1: Rebase non-conflicting | 1. latency-routing: cleanup |
| 2. Phase 1.2: Rebase conflicting | 2. Phase 0: cleanup duplicates |
| 3. Phase 0: Prepare worktree | 3. Phase 0: prepare worktree |
| … | … |

**The list opened on Phase 1.1 while the plan began at Phase 0.** The default sorted by priority and treated `sort_order` as a third-level tiebreaker, so an agent following it works a sequential plan out of order.

Priority is a reasonable guess about what matters. A sequence someone wrote down is not a guess — so it wins. When any task in the result was placed by `task_reorder`, `task_list` follows the arrangement.

### The safety half, which is the one that needed proving

For an epic nobody has arranged, the default output is **byte for byte identical** to `sort_by: "priority"`. That's a test, not a claim:

```js
assert.equal(JSON.stringify(auto), JSON.stringify(explicit));
```

An explicit `sort_by` is still obeyed literally — asking for priority gets priority, arrangement or not.

### Two details that fell out

- **`sort_order = 0` means "never placed".** `task_reorder` writes 1..N, so sorted naively that zero is the *smallest* number — a task created after an arrangement would land at the **head** of the plan, the one place it certainly doesn't belong. Unplaced tasks now sort last, in both the new default and `sort_by: "manual"`.
- **Epics are grouped before position is considered.** Position 1 of one epic and position 1 of another are unrelated; interleaving them by number would invent an order nobody set.

## #49 — finished tasks didn't look finished

Done subtasks in the drawer already rendered struck through and dimmed. The epic tree never did, so the same task looked finished in one place and open in another — the same shape as #37, where the drawer had the blocked marker and the tree didn't. `taskLine` now uses the identical treatment, which also covers the dashboard and search results.

## Verification

- **298 unit tests**, including a new `test/sort-order.test.js` covering the untouched-epic guarantee, the arrangement, explicit sorts, the late-task placement, and cross-epic grouping.
- **106 e2e checks** against the packed tarball. The gate's own `the default sort is still priority` check failed on this change, which is exactly what it's for; it now pins the new contract in three parts.
- **8 live checks** against a running server. The strike is verified through the **resolved cascade**, not just the class list — `text-decoration` is a plain keyword, so unlike a `var()` colour it's genuinely observable in jsdom.
- Both fixes confirmed to fail when reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)